### PR TITLE
Add session restart reminder to setup-project output

### DIFF
--- a/skills/universal/setup-project/SKILL.md
+++ b/skills/universal/setup-project/SKILL.md
@@ -297,5 +297,7 @@ Then include in the summary:
   /star-chamber --debate                                        - enable debate mode (2 rounds, each sees others' responses)
   /star-chamber --debate --rounds 3                             - debate mode with 3 rounds of deliberation
 
+**Important:** Start a new Claude Code session for newly linked skills to be available.
+
 **Note:** Add `**/.claude/CLAUDE.md` to .gitignore
 ```


### PR DESCRIPTION
## Summary
- Adds a note to the setup-project summary reminding users to start a new Claude Code session for newly linked skills to become available

## Test plan
- [x] Run `/setup-project` and verify the reminder appears in the output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructional guidance to clarify that a new session must be initiated for newly linked skills to become available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->