### PR TITLE
Fix openai provider warning in get_required_sdks

### DIFF
--- a/skills/advisory/star-chamber/llm_council.py
+++ b/skills/advisory/star-chamber/llm_council.py
@@ -104,8 +104,7 @@ def get_required_sdks(provider_names: list[str]) -> list[str]:
         sdk = sdk_map.get(name.lower())
         if sdk:
             sdks.append(sdk)
-        else:
-            # Warn if provider not found in sdk_map (may be using OpenAI-compatible API).
+        elif name.lower() != "openai":  # openai is the base case, no SDK needed
             print(
                 f"[star-chamber] Provider {name} not in sdk_map, assuming OpenAI-compatible",
                 file=sys.stderr,


### PR DESCRIPTION
## Summary
- Exclude openai from the "not in sdk_map" warning
- OpenAI is the base case - no extra SDK needed

## Changes
- `llm_council.py`: Add `!= "openai"` check to skip warning for the base case

## Test plan
- [ ] Run `/star-chamber --list-sdks` with openai provider - no warning

Fixes #7