### PR TITLE
Improve README clarity based on multi-LLM review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,137 @@
 # Claude Pragma
 
-Pragma directives for Claude Code - rules that stick.
+**The problem:** Claude Code follows CLAUDE.md rules inconsistently. Rules get forgotten mid-conversation, ignored during complex tasks, or applied partially. There's no enforcement mechanism.
+
+**The solution:** claude-pragma provides skills that mechanically inject rules and validate compliance. Rules aren't remembered - they're enforced by validators that run automatically on every implementation.
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A["/implement add user authentication"] --> B["Phase 0: Rules injected from .claude/CLAUDE.md files"]
+    B --> C["Phase 1-2: Claude implements following injected rules"]
+    C --> D["Phase 3: Linters run (ruff, biome, golangci-lint)"]
+    D --> E["Validators run (security, python-style, etc.)"]
+    E --> F{Pass?}
+    F -->|No| G["Fix violations"]
+    G --> D
+    F -->|Yes| H["Phase 4: Complete with validation report"]
+```
+
+**Key principle:** Validators are authoritative, not CLAUDE.md. If there's a conflict, the validator wins.
+
+## Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
+- Git
+- [uv](https://docs.astral.sh/uv/) (for Python-based validators and star-chamber)
 
 ## Quick Start
 
 ```bash
-# Clone and install
+# 1. Clone and install
 git clone git@github.com:peteski22/claude-pragma.git
 cd claude-pragma
 make install
 
-# Add to your shell profile (~/.zshrc or ~/.bashrc)
-export CLAUDE_PRAGMA_PATH="/path/to/claude-pragma"  # use actual path from make install output
+# 2. Add to your shell profile (~/.zshrc or ~/.bashrc)
+export CLAUDE_PRAGMA_PATH="$HOME/src/claude-pragma"  # adjust path as needed
 
-# In any project, run:
+# 3. Restart your shell, then in any project:
 /setup-project
+```
+
+### Example: Using /implement
+
+```bash
+> /implement add input validation to the login form
+
+[Phase 0] Injecting rules from:
+  - .claude/CLAUDE.md (universal)
+  - frontend/.claude/CLAUDE.md (typescript)
+
+[Phase 1-2] Implementing...
+  Created: frontend/src/utils/validation.ts
+  Modified: frontend/src/components/LoginForm.tsx
+
+[Phase 3] Validating...
+  ✓ biome: passed
+  ✓ tsc: passed
+  ✓ security: passed
+  ✓ typescript-style: passed
+
+[Phase 4] Complete
+  Files changed: 2
+  Validators run: 4
+  Issues: 0
 ```
 
 ## Skills
 
 ### Universal Skills
 
-| Skill | Description |
-|-------|-------------|
-| `/setup-project` | Auto-detect languages, create CLAUDE.md files, link validators |
-| `/implement <task>` | Implement with validation loop - runs linters and validators automatically |
-| `/review` | Review current changes against all validators |
+| Skill | What it does | Why it matters |
+|-------|--------------|----------------|
+| `/setup-project` | Detects languages, creates CLAUDE.md files, links validators | One command to configure any project |
+| `/implement <task>` | Implements with automatic validation loop | Catches issues before you review the code |
+| `/review` | Validates current changes against all rules | Quick check before committing |
 
 ### Validators
 
-| Skill | Language | Description |
-|-------|----------|-------------|
+Validators are semantic checks that run after linters pass. They enforce language-specific best practices.
+
+| Skill | Language | What it checks |
+|-------|----------|----------------|
 | `/validate` | All | Orchestrator - runs all applicable validators |
-| `/security` | All | Check for secrets, injection, path traversal, auth gaps |
-| `/python-style` | Python | Google docstrings, type hints, error handling, architecture |
-| `/typescript-style` | TypeScript | Strict mode, React patterns, hooks usage, state management |
-| `/go-effective` | Go | Effective Go rules - naming, error handling, interfaces |
-| `/go-proverbs` | Go | Go Proverbs - idiomatic patterns, concurrency, abstraction |
+| `/security` | All | Secrets, injection vulnerabilities, path traversal, auth gaps |
+| `/python-style` | Python | Google docstrings, type hints, exception chaining, layered architecture |
+| `/typescript-style` | TypeScript | Strict mode, React patterns, proper hooks, state management |
+| `/go-effective` | Go | Effective Go rules - naming, error handling, interface design |
+| `/go-proverbs` | Go | Go Proverbs - idiomatic patterns, concurrency, "clear is better than clever" |
 
 ### Advisory Skills
 
-| Skill | Description |
-|-------|-------------|
-| `/star-chamber` | Multi-LLM review council (OpenAI, Anthropic, Gemini) with consensus feedback |
+Advisory skills provide feedback but don't block completion.
 
-## Usage
+| Skill | What it does |
+|-------|--------------|
+| `/star-chamber` | Fans out code review to multiple LLMs (OpenAI, Anthropic, Gemini) and aggregates consensus feedback |
 
-```bash
-# Set up a new project
-/setup-project
+## Validator Severity Levels
 
-# Implement a feature (includes validation)
-/implement add user authentication
-
-# Review your changes
-/review
-
-# Get multi-LLM feedback (optional)
-/star-chamber
-/star-chamber --debate --rounds 2
-```
+| Level | Meaning | What happens |
+|-------|---------|--------------|
+| **HARD** | Must fix | Blocks `/implement` completion |
+| **SHOULD** | Fix or justify | Requires explicit justification to proceed |
+| **WARN** | Advisory | Noted in output but doesn't block |
 
 ## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CLAUDE_PRAGMA_PATH` | Yes | Path to cloned claude-pragma repo |
+| `CLAUDE_PRAGMA_PATH` | Yes | Path to your cloned claude-pragma repo |
 | `STAR_CHAMBER_CONFIG` | No | Custom path to star-chamber config (default: `~/.config/star-chamber/providers.json`) |
-| `OPENAI_API_KEY` | For star-chamber | OpenAI API key (direct mode) |
-| `ANTHROPIC_API_KEY` | For star-chamber | Anthropic API key (direct mode) |
-| `GEMINI_API_KEY` | For star-chamber | Google Gemini API key (direct mode) |
-| `ANY_LLM_KEY` | For star-chamber | Platform key from any-llm.ai (alternative to individual keys) |
+| `ANY_LLM_KEY` | For /star-chamber | Platform key from [any-llm.ai](https://any-llm.ai) |
+| `OPENAI_API_KEY` | For /star-chamber | OpenAI API key (if not using any-llm.ai) |
+| `ANTHROPIC_API_KEY` | For /star-chamber | Anthropic API key (if not using any-llm.ai) |
+| `GEMINI_API_KEY` | For /star-chamber | Google Gemini API key (if not using any-llm.ai) |
+
+## Monorepo Support
+
+`/setup-project` detects languages at root AND in subdirectories, creating appropriate CLAUDE.md files for each:
+
+```
+myproject/
+├── .claude/CLAUDE.md           # Universal rules (git workflow, code quality)
+├── backend/
+│   ├── .claude/CLAUDE.md       # Python-specific rules
+│   └── pyproject.toml
+└── frontend/
+    ├── .claude/CLAUDE.md       # TypeScript-specific rules
+    └── package.json
+```
+
+When you edit `backend/app/main.py`, both the Python rules and universal rules are injected.
 
 ## Directory Structure
 
@@ -86,39 +147,19 @@ claude-pragma/
 └── reference/              # Template configs (golangci-lint, providers.json)
 ```
 
-## Monorepo Support
-
-`/setup-project` detects languages at root AND in subdirectories:
-
-```
-myproject/
-├── .claude/CLAUDE.md           # Universal rules
-├── backend/
-│   ├── .claude/CLAUDE.md       # Python rules
-│   └── pyproject.toml
-└── frontend/
-    ├── .claude/CLAUDE.md       # TypeScript rules
-    └── package.json
-```
-
-## Validator Severity Levels
-
-| Level | Meaning | Action |
-|-------|---------|--------|
-| **HARD** | Must fix | Blocks completion |
-| **SHOULD** | Fix or justify | Requires justification to proceed |
-| **WARN** | Advisory | Noted but doesn't block |
-
 ## Gitignore
 
-Generated CLAUDE.md files should be gitignored:
+Generated CLAUDE.md files should be gitignored since each developer generates their own:
 
 ```gitignore
 **/.claude/CLAUDE.md
 ```
 
-Each developer runs `/setup-project` to generate their local copy.
-
 ## More Information
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed design decisions, validator contracts, and system flow diagrams.
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Design decisions, validator contracts, system flow diagrams
+- [Issues](https://github.com/peteski22/claude-pragma/issues) - Bug reports and feature requests
+
+## License
+
+MIT - See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Add clear problem/solution statement explaining why claude-pragma exists
- Add mermaid flow diagram showing the /implement workflow
- Add prerequisites section (Claude Code, Git, uv)
- Add concrete example showing /implement output
- Improve skills tables with "Why it matters" explanations
- Add License section and links to issues/architecture docs

## Background

This addresses consensus feedback from a `/star-chamber --debate --rounds 2` review where all three providers (OpenAI, Anthropic, Gemini) agreed the README needed:
1. Clearer value proposition upfront
2. Concrete usage examples, not just installation
3. Better explanation of how the system works
4. Missing standard sections (license, links)

## Test plan

- [ ] Verify mermaid diagram renders correctly on GitHub
- [ ] Check all links work (ARCHITECTURE.md, LICENSE, issues)
- [ ] Read through as a new user to confirm improved clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with enhanced clarity and improved organisation
  * Added problem-solution narrative introduction to the project
  * Included workflow diagrams to illustrate system functionality
  * Updated guides with revised prerequisites and Quick Start steps
  * Reorganised skills and validator information with clearer table structures
  * Added Monorepo Support documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->