### PR TITLE
Fix incorrect license type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Generated CLAUDE.md files should be gitignored since each developer generates th
 
 ## License
 
-MIT - See [LICENSE](LICENSE) for details.
+Apache 2.0 - See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Fix license type: Apache 2.0, not MIT

The previous PR incorrectly stated MIT without checking the actual LICENSE file.