### PR TITLE
Add Pattern Discovery step to Pre-Implementation Setup

### DIFF
--- a/claude-md/universal/base.md
+++ b/claude-md/universal/base.md
@@ -58,13 +58,25 @@ Before coding:
 - If the task involves breaking changes to public APIs, confirm impact with the user.
 - If the task scope seems larger than requested, verify intent before expanding.
 
+### Pattern Discovery
+
+Before proposing a solution, understand how the codebase already works.
+
+**Core principle:** Ask "how does Y access X?" not "does X exist in Y?"
+
+Checking if a directory exists tells you nothing about how code flows. Instead, trace the actual connections: grep for imports, check dependency files, examine how components are wired together.
+
+**If the task involves sharing code between components**, find existing shared packages first and follow established patterns before proposing new ones.
+
+**If a GitHub issue lists multiple approaches**, investigate each sufficiently to make an informed decision.
+
 ### Research
 
 - Where possible, use WebSearch or WebFetch to lookup current documentation rather than relying on training data, especially for:
-  - Library/framework APIs that change frequently
-  - Cloud provider documentation (AWS, GCP, Azure)
-  - Language features added recently
-  - Version-specific behavior
+  - Library/framework APIs that change frequently.
+  - Cloud provider documentation (AWS, GCP, Azure).
+  - Language features added recently.
+  - Version-specific behavior.
 
 ---
 

--- a/skills/universal/implement/SKILL.md
+++ b/skills/universal/implement/SKILL.md
@@ -88,8 +88,14 @@ The "Pre-Implementation Setup" section of the loaded rules contains **actions to
 ## Phase 1: Understand
 
 1. Clarify requirements if ambiguous.
-2. Identify files that need changes.
-3. Understand existing patterns in the codebase.
+2. **Discover existing patterns before proposing solutions:**
+   - Ask "how does Y access X?" not "does X exist in Y?" - directory existence alone doesn't reveal how code flows.
+   - Check dependency files (pyproject.toml, package.json, go.mod) for workspace/monorepo patterns.
+   - Grep for imports to understand how code flows between components.
+   - Look for build artifacts (.egg-info, .venv, dist/, node_modules/, target/) indicating local packages.
+   - If the task involves sharing code, find existing shared packages first.
+   - If the GitHub issue lists multiple approaches, investigate each sufficiently to make an informed decision.
+3. Identify files that need changes based on discovered patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Pattern Discovery section to `claude-md/universal/base.md` with the core principle: ask "how does Y access X?" not "does X exist in Y?"
- Updates `/implement` skill Phase 1 (Understand) with detailed actionable checklist for pattern discovery
- Addresses shallow research that checks file existence without understanding how code actually flows

## Changes

**base.md** - Principle-focused guidance:
- Core principle explanation
- When to apply (sharing code between components, multiple approaches in issues)

**SKILL.md** - Detailed checklist:
- Check dependency files (pyproject.toml, package.json, go.mod)
- Grep for imports to trace code flow
- Look for build artifacts (.egg-info, .venv, dist/, node_modules/, target/)
- Find existing shared packages before proposing new patterns

## Test plan

- [ ] Run `/implement` on a task involving shared code to verify pattern discovery is performed
- [ ] Verify the guidance prevents the failure mode described in the issue

Fixes #17