### PR TITLE
Fix: explicitly check for local supplements in Phase 0

### DIFF
--- a/skills/universal/implement/SKILL.md
+++ b/skills/universal/implement/SKILL.md
@@ -39,6 +39,16 @@ For a file in backend/app/handlers/:
 
 Use the Read tool to check each path. Collect those that exist.
 
+### Step 2a: Check for local supplements
+
+Also check for local supplements at the repo root:
+
+```bash
+[[ -f .claude/local/CLAUDE.md ]] && echo "local-supplements:exists"
+```
+
+If `.claude/local/CLAUDE.md` exists, read it. Local supplements contain project-specific additions (custom test commands, local environment notes, etc.) that apply in addition to generated rules.
+
 ### Step 3: Read and apply rules
 
 Read each discovered CLAUDE.md file.
@@ -56,7 +66,7 @@ If two rules conflict and precedence is unclear, prefer the more specific rule a
 
 ### Step 4: Record applied rules
 
-Track which rule files were loaded for the final report.
+Track which rule files were loaded for the final report, including local supplements if present.
 
 ### Step 5: Execute pre-implementation setup
 
@@ -158,6 +168,7 @@ Only after validation passes:
 **Rules Applied:**
 - backend/.claude/CLAUDE.md
 - .claude/CLAUDE.md
+- .claude/local/CLAUDE.md (local supplements)
 
 **Changes:**
 - file.go: [what changed]


### PR DESCRIPTION
## Problem

Claude instances were not reading `.claude/local/CLAUDE.md` even though the generated rules mention it. The rules passively said "if it exists, read it" but the `/implement` skill didn't explicitly instruct Claude to check for it during Phase 0.

Feedback from another Claude instance:
> I missed it because I didn't follow my own Phase 0 instructions properly - I read the root .claude/CLAUDE.md which mentions checking for local supplements, but I didn't actually read .claude/local/CLAUDE.md.

## Solution

Add explicit "Step 2a: Check for local supplements" to Phase 0 that instructs Claude to check for and read the local supplements file.

## Changes

- Added Step 2a with bash check: `[[ -f .claude/local/CLAUDE.md ]] && echo "local-supplements:exists"`
- Updated Step 4 to mention tracking local supplements
- Updated output format example to show local supplements in Rules Applied

## Test plan

- [ ] Run `/implement` on a project with `.claude/local/CLAUDE.md` and verify it gets read
- [ ] Verify the rules from local supplements are applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Release Notes**

* **New Features**
  * Introduced support for local project-specific supplements that integrate seamlessly with standard rules. The system now automatically detects and applies local supplements alongside generated rules, with enhanced tracking and reporting capabilities to display all active configuration sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->