### PR TITLE
Fix setup-project exit code 1 when all checks pass

### DIFF
--- a/skills/universal/setup-project/SKILL.md
+++ b/skills/universal/setup-project/SKILL.md
@@ -18,6 +18,7 @@ echo "$CLAUDE_PRAGMA_PATH"
 [[ -z "$CLAUDE_PRAGMA_PATH" ]] && echo "ERROR: CLAUDE_PRAGMA_PATH not set"
 [[ ! -d "$CLAUDE_PRAGMA_PATH" ]] && echo "ERROR: CLAUDE_PRAGMA_PATH does not exist"
 [[ ! -f "$CLAUDE_PRAGMA_PATH/claude-md/universal/base.md" ]] && echo "ERROR: Invalid claude-pragma repo"
+true  # Ensure exit 0; Claude Code reads ERROR output and stops (see below).
 ```
 
 If not set, tell the user:


### PR DESCRIPTION
## Summary
- Fixes unexplained "Error: Exit code 1" when CLAUDE_PRAGMA_PATH is correctly configured
- Adds `true` with explanatory comment at end of validation bash block
- The block is informational-only; Claude Code reads ERROR output and stops execution

## Test plan
- [ ] Run `/setup-project` with valid CLAUDE_PRAGMA_PATH - should not show exit code 1
- [ ] Run `/setup-project` with invalid path - should still show ERROR messages

Fixes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where the setup script would report an incorrect exit status when errors were encountered, ensuring consistent success signalling during project initialisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->