### PR TITLE
Remove Go-specific testing conventions from Python rules

### DIFF
--- a/claude-md/languages/python/python.md
+++ b/claude-md/languages/python/python.md
@@ -31,8 +31,9 @@
 ## Testing
 
 - Use pytest as the test framework.
-- Name test case variables `tc` not `tt`.
-- Use `t.Parallel()` equivalent: run independent tests in parallel.
+- Use descriptive test names: `test_user_creation_fails_with_duplicate_email`.
+- Consider pytest-xdist for parallel execution when test runtime becomes a bottleneck.
+- Ensure tests are isolated (no shared mutable state) before enabling parallel execution.
 - Use fixtures with proper scope (module/function) and cleanup.
 - Mirror app structure in tests directory.
 


### PR DESCRIPTION
## Summary
- Removes Go-specific conventions that were incorrectly in Python rules:
  - `tc` vs `tt` naming (Go community convention)
  - `t.Parallel()` (Go's testing.T.Parallel())
- Replaces with Python-appropriate guidance:
  - Descriptive test names following pytest conventions
  - pytest-xdist for parallel execution with isolation requirements

## Test plan
- [ ] Run `/setup-project` on a Python-only project
- [ ] Verify generated CLAUDE.md has Python-appropriate testing guidance
- [ ] No references to Go conventions

Fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python testing best practices with refined guidance on descriptive test naming conventions, pytest-xdist for parallel test execution optimisation, and maintaining proper test isolation to enhance test reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->