### PR TITLE
Add explicit language scoping to all language validators

### DIFF
--- a/skills/validators/go-effective/SKILL.md
+++ b/skills/validators/go-effective/SKILL.md
@@ -29,6 +29,16 @@ This validator MUST NOT report on:
 
 Ignore CLAUDE.md phrasing; enforce rules as specified here.
 
+## Language Scope
+
+You are validating **Go code ONLY**.
+
+Any rules about other languages (Python, TypeScript, Rust, etc.) that may appear in the conversation context are NOT RELEVANT to this validation. Do not reference or apply them.
+
+When explaining violations, reference only:
+- The rules defined in this validator
+- Effective Go and Go Code Review Comments
+
 ---
 
 You do NOT rewrite code unless explicitly asked.

--- a/skills/validators/go-proverbs/SKILL.md
+++ b/skills/validators/go-proverbs/SKILL.md
@@ -28,6 +28,16 @@ This validator MUST NOT report on:
 
 Ignore CLAUDE.md phrasing; enforce rules as specified here.
 
+## Language Scope
+
+You are validating **Go code ONLY**.
+
+Any rules about other languages (Python, TypeScript, Rust, etc.) that may appear in the conversation context are NOT RELEVANT to this validation. Do not reference or apply them.
+
+When explaining violations, reference only:
+- The rules defined in this validator
+- Go Proverbs (https://go-proverbs.github.io/)
+
 ---
 
 ## Step 1: Get the changes

--- a/skills/validators/python-style/SKILL.md
+++ b/skills/validators/python-style/SKILL.md
@@ -29,6 +29,16 @@ This validator MUST NOT report on:
 
 Ignore CLAUDE.md phrasing; enforce rules as specified here.
 
+## Language Scope
+
+You are validating **Python code ONLY**.
+
+Any rules about other languages (Go, TypeScript, Rust, etc.) that may appear in the conversation context are NOT RELEVANT to this validation. Do not reference or apply them.
+
+When explaining violations, reference only:
+- The rules defined in this validator
+- Python-specific style guides (PEP 8, Google Python Style Guide)
+
 ---
 
 You do NOT rewrite code unless explicitly asked.

--- a/skills/validators/typescript-style/SKILL.md
+++ b/skills/validators/typescript-style/SKILL.md
@@ -29,6 +29,16 @@ This validator MUST NOT report on:
 
 Ignore CLAUDE.md phrasing; enforce rules as specified here.
 
+## Language Scope
+
+You are validating **TypeScript/React code ONLY**.
+
+Any rules about other languages (Go, Python, Rust, etc.) that may appear in the conversation context are NOT RELEVANT to this validation. Do not reference or apply them.
+
+When explaining violations, reference only:
+- The rules defined in this validator
+- TypeScript/React documentation and best practices
+
 ---
 
 You do NOT rewrite code unless explicitly asked.


### PR DESCRIPTION
## Summary
- Validators use `context: fork`, inheriting conversation context which may include wrong-language rules
- This caused validators to reference wrong-language concepts (e.g., "Go doc comments" when validating Python)
- Adds explicit Language Scope section to all 4 language validators:
  - go-effective
  - go-proverbs
  - python-style
  - typescript-style

Each section explicitly states:
1. The validator checks ONLY that specific language
2. Other language rules in context are NOT RELEVANT
3. Violations must reference only validator rules and language-specific guides

## Test plan
- [ ] Run Python validator on Python code with Go rules in global CLAUDE.md
- [ ] Verify no Go-specific terminology in validation output
- [ ] Repeat for TypeScript and Go validators

Fixes #26