### PR TITLE
Add anti-pattern propagation rule to Python and TypeScript validators

### DIFF
--- a/skills/validators/python-style/SKILL.md
+++ b/skills/validators/python-style/SKILL.md
@@ -77,6 +77,15 @@ Do not invent rules.
 Do not relax rules.
 Do not apply personal preference.
 
+**CRITICAL: Anti-Pattern Propagation**
+
+Consistency with existing bad code is NOT a defense. If new code matches an existing pattern in the file, you MUST still evaluate whether that pattern violates Python idioms. Existing violations do not justify new violations.
+
+If you see new code copying an anti-pattern from existing code:
+1. Flag the new code as a violation
+2. Note in the explanation that the existing code also has this issue
+3. Do NOT skip the violation because "it matches existing code"
+
 ---
 
 ## HARD RULES (MUST PASS)

--- a/skills/validators/typescript-style/SKILL.md
+++ b/skills/validators/typescript-style/SKILL.md
@@ -77,6 +77,15 @@ Do not invent rules.
 Do not relax rules.
 Do not apply personal preference.
 
+**CRITICAL: Anti-Pattern Propagation**
+
+Consistency with existing bad code is NOT a defense. If new code matches an existing pattern in the file, you MUST still evaluate whether that pattern violates TypeScript/React idioms. Existing violations do not justify new violations.
+
+If you see new code copying an anti-pattern from existing code:
+1. Flag the new code as a violation
+2. Note in the explanation that the existing code also has this issue
+3. Do NOT skip the violation because "it matches existing code"
+
 ---
 
 ## HARD RULES (MUST PASS)


### PR DESCRIPTION
## Summary
- The go-effective validator already has this rule, but python-style and typescript-style were missing it
- This allowed Claude to justify bad patterns with "codebase consistency":
  > "The llama_index.py file uses the same pattern. This is consistent with the codebase style."
- Adds the same anti-pattern propagation rule to both validators:
  1. Flag new code as a violation
  2. Note that existing code also has the issue
  3. Do NOT skip because "it matches existing code"

## Test plan
- [ ] Run Python validator on code that copies an anti-pattern from existing code
- [ ] Verify it flags the violation and notes the existing issue
- [ ] Verify "codebase consistency" is not accepted as justification

Fixes #27