### PR TITLE
Add concrete examples to Pattern Discovery guidance

### DIFF
--- a/claude-md/universal/base.md
+++ b/claude-md/universal/base.md
@@ -67,7 +67,7 @@ Before proposing a solution, understand how the codebase already works.
 Checking if a directory exists tells you nothing about how code flows. Instead, trace the actual connections: grep for imports, check dependency files, examine how components are wired together.
 
 **Concrete checks before implementing:**
-- **File paths/config locations:** Grep for similar paths to find existing constants or variables instead of hardcoding strings.
+- **File paths/config locations:** Search for similar paths to find existing constants or variables instead of hardcoding strings.
 - **Error messages:** Check how errors are formatted elsewhere (wrapping patterns, message style).
 - **API responses:** Find existing response structures before creating new ones.
 - **Logging:** Match existing log levels, formats, and context fields.


### PR DESCRIPTION
## Summary
- The Pattern Discovery section had good principles but lacked concrete examples
- In another session, Claude used a hardcoded path instead of an existing constant because the guidance was too abstract
- Adds specific checks for:
  - File paths/config locations (grep for existing constants)
  - Error messages (match existing formatting)
  - API responses (find existing structures)
  - Logging (match levels, formats, context)
  - Dependencies (check if already available)

## Test plan
- [ ] Use `/implement` on a task involving file paths
- [ ] Verify Claude searches for existing constants before hardcoding
- [ ] Verify concrete checks are mentioned in implementation approach

Fixes #28