### PR TITLE
Add testability design guidance to language rules

### DIFF
--- a/claude-md/languages/go/go.md
+++ b/claude-md/languages/go/go.md
@@ -52,6 +52,12 @@
 - Prefer type assertion over expanding interfaces.
 - Keep interfaces small and focused.
 
+## Testability
+
+- Extract logic that depends on framework/external state into pure functions.
+- When validation depends on framework state (e.g., Cobra's `ArgsLenAtDash()`), create a wrapper that calls a testable pure function.
+- Prefer dependency injection over global state.
+
 ## Testing
 
 - Name test case variable 'tc' not 'tt'.

--- a/claude-md/languages/python/python.md
+++ b/claude-md/languages/python/python.md
@@ -28,11 +28,18 @@
 - Always chain exceptions with `raise ... from e`.
 - Don't use bare `except:` clauses.
 
+## Testability
+
+- Extract logic that depends on framework/external state into pure functions.
+- When validation depends on framework state (e.g., FastAPI request objects), create a wrapper that calls a testable pure function.
+- Prefer dependency injection over global state.
+
 ## Testing
 
 - Use pytest as the test framework.
-- Name test case variables `tc` not `tt`.
-- Use `t.Parallel()` equivalent: run independent tests in parallel.
+- Use descriptive test names: `test_user_creation_fails_with_duplicate_email`.
+- Consider pytest-xdist for parallel execution when test runtime becomes a bottleneck.
+- Ensure tests are isolated (no shared mutable state) before enabling parallel execution.
 - Use fixtures with proper scope (module/function) and cleanup.
 - Mirror app structure in tests directory.
 

--- a/claude-md/languages/typescript/typescript.md
+++ b/claude-md/languages/typescript/typescript.md
@@ -38,6 +38,12 @@
 - Use error boundaries for component-level errors.
 - Provide meaningful error messages to users.
 
+## Testability
+
+- Extract logic that depends on framework/external state into pure functions.
+- When business logic depends on hooks or context, create a pure function that the hook calls.
+- Prefer dependency injection over global state.
+
 ## Testing
 
 - Use Vitest as the test framework.


### PR DESCRIPTION
## Summary
- Current testing rules focus on test file structure but don't address designing production code for testability
- Adds Testability section to all language rules:
  - **Go:** Extract logic from Cobra/framework state into pure functions
  - **Python:** Extract logic from FastAPI/framework objects into pure functions
  - **TypeScript:** Extract logic from hooks/context into pure functions
- All emphasize dependency injection over global state

Note: Also includes Python testing fixes from #25 since this branch is based on main.

## Test plan
- [ ] Use `/implement` to add validation logic that depends on framework state
- [ ] Verify Claude extracts a testable pure function
- [ ] Verify tests can be written without mocking framework state

Fixes #29