### PR TITLE
Add safety comment guidance for slice/array operations

### DIFF
--- a/claude-md/languages/go/go.md
+++ b/claude-md/languages/go/go.md
@@ -58,6 +58,12 @@
 - When validation depends on framework state (e.g., Cobra's `ArgsLenAtDash()`), create a wrapper that calls a testable pure function.
 - Prefer dependency injection over global state.
 
+## Comments
+
+- When slice/array operations depend on prior validation, add a brief comment referencing the guarantee.
+  - Example: `// args[1:] is safe: validateArgs guarantees len(args) >= 2`
+- This documents safety invariants for readers and protects against refactoring mistakes.
+
 ## Testing
 
 - Name test case variable 'tc' not 'tt'.


### PR DESCRIPTION
## Summary
- When slice operations depend on prior validation, there was no rule about documenting the safety invariant
- Adds Comments section to Go rules with guidance:
  - When slice/array operations depend on prior validation, add a brief comment
  - Example: `// args[1:] is safe: validateArgs guarantees len(args) >= 2`
- This is distinct from "obvious" comments because:
  - The safety guarantee may be defined elsewhere
  - It protects against refactoring mistakes
  - It makes code review easier

## Test plan
- [ ] Use `/implement` to add code with slice operations after validation
- [ ] Verify Claude adds a safety comment referencing the validation
- [ ] Verify comment explains why the operation is safe

Fixes #30