### PR TITLE
Add principle: find existing instances when implementing new ones

### DIFF
--- a/claude-md/universal/base.md
+++ b/claude-md/universal/base.md
@@ -66,6 +66,8 @@ Before proposing a solution, understand how the codebase already works.
 
 Checking if a directory exists tells you nothing about how code flows. Instead, trace the actual connections: grep for imports, check dependency files, examine how components are wired together.
 
+**When implementing a new instance of something, find existing instances first.** Adding a new API endpoint? Study existing endpoints. New CLI command? Look at similar commands. New provider/adapter? Find existing providers. Copy their patterns unless there's a specific reason to deviate.
+
 **Concrete checks before implementing:**
 - **File paths/config locations:** Search for similar paths to find existing constants or variables instead of hardcoding strings.
 - **Error messages:** Check how errors are formatted elsewhere (wrapping patterns, message style).


### PR DESCRIPTION
## Summary

When implementing a new instance of something (API endpoint, CLI command, provider, etc.), find existing instances first and copy their patterns unless there's a specific reason to deviate.

**Added to Pattern Discovery section:**
> **When implementing a new instance of something, find existing instances first.** Adding a new API endpoint? Study existing endpoints. New CLI command? Look at similar commands. New provider/adapter? Find existing providers. Copy their patterns unless there's a specific reason to deviate.

## Context

This addresses feedback from another Claude session where Claude invented its own validation order instead of copying the proven pattern from similar existing commands:

> I read similar commands superficially - I looked at `args/set.go` and `env/set.go` for the general structure but didn't carefully study the validation logic. I invented my own validation order instead of copying the proven pattern.

## Test plan
- [ ] Use `/implement` to add a new CLI command
- [ ] Verify Claude finds and studies existing similar commands first
- [ ] Verify Claude copies validation patterns from existing commands

Follow-up to #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated developer guidance to promote reuse of existing patterns when implementing new features, including concrete examples for endpoints, CLI commands, and provider/adapter implementations. Expanded verification checklist to validate existing patterns and dependencies before proposing new implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->