### PR TITLE
Fix implement skill to use fallback baseline rules

### DIFF
--- a/skills/universal/implement/SKILL.md
+++ b/skills/universal/implement/SKILL.md
@@ -37,7 +37,7 @@ For a file in backend/app/handlers/:
   Check: .claude/CLAUDE.md (root)
 ```
 
-Use the Read tool to check each path. Collect those that exist.
+Use the Read tool to check each path. Collect those that exist and are readable. A file is considered "found" only if it exists and can be successfully read.
 
 ### Step 2a: Check for local supplements
 
@@ -68,18 +68,18 @@ If two rules conflict and precedence is unclear, prefer the more specific rule a
 
 **This step only applies if NO `.claude/CLAUDE.md` files were found in Step 2.**
 
-If project-specific rules exist, skip this step entirely—do not load the fallback baseline.
+If project-specific rules were found and loaded, skip this step entirely and note in report: "Fallback baseline: not needed (project rules loaded)"
 
 If no project-specific rules were found, attempt to load the universal baseline:
 
 1. **Check environment variable:** Is `$CLAUDE_PRAGMA_PATH` set and non-empty?
-   - If unset or empty → skip fallback, note in report: "No project rules found; CLAUDE_PRAGMA_PATH not set"
+   - If unset or empty → skip fallback, note in report: "Fallback baseline: skipped (CLAUDE_PRAGMA_PATH not set)"
 
 2. **Validate file exists:** Does `$CLAUDE_PRAGMA_PATH/claude-md/universal/base.md` exist and is it readable?
-   - If file missing or unreadable → skip fallback, note in report: "No project rules found; baseline file not found at $CLAUDE_PRAGMA_PATH/claude-md/universal/base.md"
+   - If file missing or unreadable → skip fallback, note in report: "Fallback baseline: failed (file not found at $CLAUDE_PRAGMA_PATH/claude-md/universal/base.md)"
 
 3. **Load baseline:** If both checks pass, read `$CLAUDE_PRAGMA_PATH/claude-md/universal/base.md` as the baseline rules.
-   - Note in report: "No project rules found; loaded universal baseline from $CLAUDE_PRAGMA_PATH"
+   - Note in report: "Fallback baseline: loaded from $CLAUDE_PRAGMA_PATH"
 
 This fallback ensures projects without `/setup-project` still get essential rules (branch creation, scope verification, etc.).
 
@@ -87,7 +87,7 @@ This fallback ensures projects without `/setup-project` still get essential rule
 
 Track which rule files were loaded for the final report, including:
 - Which project-specific CLAUDE.md files were loaded (if any)
-- Whether fallback baseline was used (and why, if it couldn't be loaded)
+- Fallback baseline status: not needed, loaded, skipped, or failed (with reason)
 - Local supplements if present
 
 ### Step 5: Execute pre-implementation setup


### PR DESCRIPTION
## Summary

- Adds `$CLAUDE_PRAGMA_PATH/claude-md/universal/base.md` as a fallback when no project `.claude/CLAUDE.md` files exist
- Ensures projects without `/setup-project` still get branch creation, scope verification, and other pre-implementation steps

**Problem:** Running `/implement` on a project without `.claude/CLAUDE.md` files silently skipped pre-implementation setup (including branch creation), because the skill only looked for project-specific rules.

**Solution:** Fall back to the universal baseline rules when no project rules exist.

## Test plan

- [ ] Run `/implement` on a project without `.claude/CLAUDE.md` files but with `$CLAUDE_PRAGMA_PATH` set
- [ ] Verify branch creation prompt appears
- [ ] Run `/implement` on a project with `.claude/CLAUDE.md` files and verify existing behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a conditional fallback baseline that loads only when no project rules are present.
  * More granular reporting of which project rule files were loaded and whether a fallback was used.

* **Documentation**
  * Added guidance on fallback behaviour, rule precedence and conflict resolution.
  * Clarified execution model for pre-implementation setup, including skipping when no relevant section exists and how actions/outcomes are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->