### PR TITLE
Migrate from .claude/local/CLAUDE.md to native CLAUDE.local.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ Advisory skills provide feedback but don't block completion.
 ```
 myproject/
 ├── .claude/
-│   ├── CLAUDE.md               # Universal rules (commit this)
-│   └── local/
-│       └── CLAUDE.md           # Personal supplements (gitignore this)
+│   └── CLAUDE.md               # Universal rules (commit this)
+├── CLAUDE.local.md             # Personal supplements (gitignored)
 ├── backend/
 │   ├── .claude/CLAUDE.md       # Python-specific rules
 │   └── pyproject.toml
@@ -134,7 +133,7 @@ myproject/
     └── package.json
 ```
 
-When you edit `backend/app/main.py`, both the Python rules and universal rules are injected. If `.claude/local/CLAUDE.md` exists, those rules are also applied as supplements.
+When you edit `backend/app/main.py`, both the Python rules and universal rules are injected. If `CLAUDE.local.md` exists at the project root, it is auto-loaded by Claude Code as per-user supplements.
 
 ## Directory Structure
 
@@ -154,10 +153,12 @@ claude-pragma/
 
 **Commit** the generated `.claude/CLAUDE.md` files so other developers get the same rules without re-running `/setup-project`.
 
-**Gitignore** the `.claude/local/` directory for personal supplements:
+Claude Code adds `CLAUDE.local.md` to `.gitignore` automatically when it creates the file. If you create it manually, verify it is in your `.gitignore` to avoid committing personal rules.
 
-```gitignore
-.claude/local/
+In git worktrees, use `@import` (a Claude Code directive that includes another CLAUDE.md file) in `CLAUDE.local.md` to reference a shared local rules file rather than duplicating it per worktree:
+
+```markdown
+@import ../shared-local-rules.md
 ```
 
 ## More Information

--- a/claude-md/languages/go/go.md
+++ b/claude-md/languages/go/go.md
@@ -73,6 +73,6 @@
 
 ## Validation Commands
 
-These commands are used by `/implement` and `/review` during validation. Override in `.claude/local/CLAUDE.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `golangci-lint run --fix -v`

--- a/claude-md/languages/python/python.md
+++ b/claude-md/languages/python/python.md
@@ -51,6 +51,6 @@
 
 ## Validation Commands
 
-These commands are used by `/implement` and `/review` during validation. Override in `.claude/local/CLAUDE.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `uv run pre-commit run --all-files`

--- a/claude-md/languages/typescript/typescript.md
+++ b/claude-md/languages/typescript/typescript.md
@@ -60,7 +60,7 @@
 
 ## Validation Commands
 
-These commands are used by `/implement` and `/review` during validation. Override in `.claude/local/CLAUDE.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `pnpm run lint`
 - **Test:** `pnpm run test`

--- a/claude-md/universal/context-aware.md
+++ b/claude-md/universal/context-aware.md
@@ -11,8 +11,6 @@ Always apply the most specific rules available for the code you're working on.
 
 ## Local Supplements
 
-If `.claude/local/CLAUDE.md` exists, read it and apply those rules in addition to the generated rules.
+`CLAUDE.local.md` at the project root contains per-user, per-project instructions. Claude Code auto-loads it and adds it to `.gitignore`; if you create the file manually, verify it is in your `.gitignore`.
 
-Local supplements are generally additive. The one exception: a "Validation Commands" section in local supplements overrides the default lint/test commands. This allows per-machine customization of validation scripts without modifying version-controlled rules.
-
-Add `.claude/local/` to your `.gitignore` to keep personal rules out of version control.
+Rules from `CLAUDE.local.md` are additive to the rules in this file. The one exception: if `CLAUDE.local.md` contains a "Validation Commands" section, use those commands instead of the defaults. This allows per-machine customization of validation scripts without modifying version-controlled rules.

--- a/claude-md/universal/validation-precedence.md
+++ b/claude-md/universal/validation-precedence.md
@@ -4,7 +4,7 @@ This document defines the priority order for validation commands used by `/imple
 
 ## Priority Order (Highest to Lowest)
 
-1. **`.claude/local/CLAUDE.md`** - Personal/machine-specific overrides
+1. **`CLAUDE.local.md`** - Personal/machine-specific overrides (gitignored, per-user)
 2. **`{subdir}/.claude/CLAUDE.md`** - Project component rules
 3. **`.claude/CLAUDE.md`** - Repository root rules
 4. **Built-in defaults** - Language-specific fallbacks
@@ -31,7 +31,7 @@ Validation commands are configured at the repository root by the setup-project s
 - **Test:** `uv run pytest -x`
 ```
 
-**Local overrides** (`.claude/local/CLAUDE.md`) - machine-specific, not committed:
+**Local overrides** (`CLAUDE.local.md`) - machine-specific, gitignored:
 ```markdown
 ## Validation Commands
 - **Lint:** `./scripts/my-lint.sh`
@@ -58,5 +58,5 @@ Your personal global CLAUDE.md (`~/.claude/CLAUDE.md`) is **separate from this p
 
 **Recommendations:**
 - Keep personal CLAUDE.md language-agnostic (workflow preferences, communication style)
-- Put language-specific personal preferences in `.claude/local/CLAUDE.md` within each project
+- Put language-specific personal preferences in `CLAUDE.local.md` within each project
 - Validators have explicit Language Scope sections to prevent cross-language contamination

--- a/skills/universal/implement/SKILL.md
+++ b/skills/universal/implement/SKILL.md
@@ -41,13 +41,13 @@ Use the Read tool to check each path. Collect those that exist and are readable.
 
 ### Step 2a: Check for local supplements
 
-Also check for local supplements at the repo root:
+Check for `CLAUDE.local.md` at the project root and read it if present:
 
 ```bash
-[[ -f .claude/local/CLAUDE.md ]] && echo "local-supplements:exists"
+[[ -f CLAUDE.local.md ]] && echo "local-supplements:exists"
 ```
 
-If `.claude/local/CLAUDE.md` exists, read it. Local supplements contain project-specific additions (custom test commands, local environment notes, etc.) that apply in addition to generated rules.
+If it exists, read it. Pay particular attention to any "Validation Commands" section, which overrides defaults. Claude Code may also auto-load this file into context; the explicit read here ensures local supplements are always applied regardless of execution environment.
 
 ### Step 3: Read and apply rules
 
@@ -88,7 +88,7 @@ This fallback ensures projects without `/setup-project` still get essential rule
 Track which rule files were loaded for the final report, including:
 - Which project-specific CLAUDE.md files were loaded (if any)
 - Fallback baseline status: not needed, loaded, skipped, or failed (with reason)
-- Local supplements if present
+- CLAUDE.local.md (auto-loaded or explicitly read in Step 2a)
 
 ### Step 5: Execute pre-implementation setup
 
@@ -148,14 +148,17 @@ After implementation is complete, run validation.
 1. **Run linters first** (deterministic checks):
 
    **Check rules for custom validation commands:**
-   Look for a "Validation Commands" section in the loaded rules (from Phase 0). This section contains project-specific lint/test commands that override the defaults below.
+   Look for a "Validation Commands" section in these sources, in precedence order:
+   1. `CLAUDE.local.md` (from Step 2a — highest priority)
+   2. Directory-specific `.claude/CLAUDE.md` files (from Step 2)
+   3. Root `.claude/CLAUDE.md` (from Step 2)
 
-   If custom commands exist, use them. Otherwise, fall back to these defaults:
+   If custom commands exist at any level, use the highest-precedence match. Otherwise, fall back to these defaults:
    - Go: `golangci-lint run --fix -v`
    - Python: `uv run pre-commit run --all-files`
    - TypeScript: `pnpm run lint` or `npx biome check .`
 
-   **Priority order:** See `claude-md/universal/validation-precedence.md` for the canonical precedence rules. In short: local supplements > subdirectory rules > root rules > built-in defaults. Local supplements have the highest priority to allow per-machine customization without modifying version-controlled rules.
+   **Priority order:** See `claude-md/universal/validation-precedence.md` for the canonical precedence rules. In short: CLAUDE.local.md > subdirectory rules > root rules > built-in defaults. CLAUDE.local.md has the highest priority to allow per-machine customization without modifying version-controlled rules.
 
    Fix any issues before proceeding.
 
@@ -198,7 +201,7 @@ Only after validation passes:
 **Rules Applied:**
 - backend/.claude/CLAUDE.md
 - .claude/CLAUDE.md
-- .claude/local/CLAUDE.md (local supplements)
+- CLAUDE.local.md (from Step 2a)
 
 **Changes:**
 - file.go: [what changed]

--- a/skills/universal/review/SKILL.md
+++ b/skills/universal/review/SKILL.md
@@ -53,20 +53,23 @@ Record which rule files were loaded.
 
 ## Step 2a: Check for local supplements
 
-Also check for local supplements at the repo root:
+Check for `CLAUDE.local.md` at the project root and read it if present:
 
 ```bash
-[[ -f .claude/local/CLAUDE.md ]] && echo "local-supplements:exists"
+[[ -f CLAUDE.local.md ]] && echo "local-supplements:exists"
 ```
 
-If `.claude/local/CLAUDE.md` exists, read it. Local supplements may contain custom validation commands that override the defaults.
+If it exists, read it. Pay particular attention to any "Validation Commands" section, which overrides defaults. Claude Code may also auto-load this file into context; the explicit read here ensures local supplements are always applied regardless of execution environment.
 
 ## Step 3: Run deterministic checks
 
 **Check rules for custom validation commands first:**
-Look for a "Validation Commands" section in the loaded rules (from Step 2 and Step 2a). This section contains project-specific lint/test commands that override the defaults below.
+Look for a "Validation Commands" section in these sources, in precedence order:
+1. `CLAUDE.local.md` (from Step 2a — highest priority)
+2. Directory-specific `.claude/CLAUDE.md` files (from Step 2)
+3. Root `.claude/CLAUDE.md` (from Step 2)
 
-**Priority order:** See `claude-md/universal/validation-precedence.md` for the canonical precedence rules. In short: local supplements > subdirectory rules > root rules > built-in defaults. Local supplements have the highest priority to allow per-machine customization without modifying version-controlled rules.
+Use the highest-precedence match. See `claude-md/universal/validation-precedence.md` for the canonical precedence rules.
 
 If no custom commands found, use these defaults based on file types:
 

--- a/skills/universal/setup-project/SKILL.md
+++ b/skills/universal/setup-project/SKILL.md
@@ -88,10 +88,9 @@ If any exist, read them. If they have `<!-- Assembled by /setup-project -->` com
 
 ## Step 4: Create root .claude/CLAUDE.md
 
-Create the directories:
+Create the directory:
 ```bash
 mkdir -p .claude
-mkdir -p .claude/local
 ```
 
 Assemble root CLAUDE.md with:
@@ -124,11 +123,11 @@ Always apply the most specific rules available for the code you're working on.
      Update both files together if this guidance changes. -->
 ## Local Supplements
 
-If `.claude/local/CLAUDE.md` exists, read it and apply those rules in addition to the generated rules.
+`CLAUDE.local.md` at the project root contains per-user, per-project instructions. Claude Code auto-loads it and adds it to `.gitignore`; if you create the file manually, verify it is in your `.gitignore`.
 
 ### Validation Command Overrides
 
-Local supplements are generally additive, but can override validation commands. Add a "Validation Commands" section to specify custom lint/test scripts:
+Rules from `CLAUDE.local.md` are generally additive, but can override validation commands. Add a "Validation Commands" section to `CLAUDE.local.md` to specify custom lint/test scripts:
 
 ```markdown
 ## Validation Commands
@@ -137,7 +136,7 @@ Local supplements are generally additive, but can override validation commands. 
 - **Test:** `./scripts/backend-test.sh`
 ```
 
-These override the defaults in the language rules. Precedence (highest → lowest): local supplements > subdirectory rules > root rules > built-in defaults.
+These override the defaults in the language rules. Precedence (highest → lowest): CLAUDE.local.md > subdirectory rules > root rules > built-in defaults.
 
 **Common scenarios for overriding validation commands:**
 
@@ -154,12 +153,13 @@ These override the defaults in the language rules. Precedence (highest → lowes
 - Personal workflow preferences.
 - Machine-specific paths or configurations.
 
-Add `.claude/local/` to your `.gitignore` to keep personal rules out of version control.
+In git worktrees, use `@import` (a Claude Code directive that includes another CLAUDE.md file) in `CLAUDE.local.md` to reference a shared local rules file rather than duplicating it per worktree (e.g., `@import ../shared-local-rules.md`).
 ```
 
-**Create empty local CLAUDE.md (only if it doesn't exist):**
+**Create local supplements file and ensure it is gitignored:**
 ```bash
-[[ ! -f .claude/local/CLAUDE.md ]] && touch .claude/local/CLAUDE.md
+[[ ! -f CLAUDE.local.md ]] && touch CLAUDE.local.md
+grep -qxF 'CLAUDE.local.md' .gitignore 2>/dev/null || echo 'CLAUDE.local.md' >> .gitignore
 ```
 
 ## Step 5: Create subdirectory .claude/CLAUDE.md files
@@ -348,5 +348,5 @@ Then continue with:
 
 **Recommended:**
   - Commit the generated `.claude/CLAUDE.md` files so other developers get the same rules.
-  - Add `.claude/local/` to `.gitignore` for personal supplements.
+  - `CLAUDE.local.md` has been created for personal/machine-specific rules (custom validation commands, local environment notes, personal workflow preferences). It is auto-loaded by Claude Code and gitignored.
 ```


### PR DESCRIPTION
## Summary

- Migrate all references from `.claude/local/CLAUDE.md` to native `CLAUDE.local.md` across 9 files
- Leverage Claude Code's native auto-loading of `CLAUDE.local.md` (per-project, per-user, auto-gitignored), eliminating the fragile meta-instruction pattern that was inconsistently followed
- Keep Step 2a in implement/review skills as a mechanical fallback — explicit file read ensures local supplements are always applied regardless of execution environment
- setup-project now creates `CLAUDE.local.md` at project root and idempotently adds it to `.gitignore`
- Add `@import` directive documentation for git worktree workflows

## Test plan

- [ ] `grep -r '.claude/local' --include='*.md' .` returns zero results
- [ ] Read each changed file for internal consistency (no mixed old/new paths)
- [ ] Verify setup-project SKILL.md no longer creates `.claude/local/` directory
- [ ] Verify implement and review SKILL.md Step 2a uses mechanical `[[ -f CLAUDE.local.md ]]` check
- [ ] Verify validation command precedence lists are consistent across implement, review, and validation-precedence.md
- [ ] Run `/setup-project` on a test repo and confirm `CLAUDE.local.md` is created at root and added to `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidelines with new project-level file structure and naming conventions
  * Revised local override precedence rules and gitignore handling guidance across all language-specific and universal documentation
  * Added detailed worktree configuration examples demonstrating per-user customisation approaches
  * Clarified separation between machine-specific user configuration and version-controlled project rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->