### PR TITLE
Fix skill command references to use short form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	@echo "Installing legacy symlinks for migration..."
 	@mkdir -p ~/.claude/skills
 	@ln -sf "$(CURDIR)/plugins/pragma/skills/setup-project" ~/.claude/skills/
-	@echo "Linked skill: /setup-project (deprecated; use /pragma:setup-project via plugin install)"
+	@echo "Linked skill: /setup-project (deprecated; use /setup-project via plugin install)"
 	@mkdir -p ~/.claude/agents
 	@for agent in "$(CURDIR)"/plugins/pragma/agents/*.md; do \
 		if [ -f "$$agent" ]; then \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```mermaid
 flowchart TD
-    A["/pragma:implement add user authentication"] --> B["Phase 0: Rules injected from .claude/CLAUDE.md files"]
+    A["/implement add user authentication"] --> B["Phase 0: Rules injected from .claude/CLAUDE.md files"]
     B --> C["Phase 1-2: Claude implements following injected rules"]
     C --> D["Phase 3: Linters run (ruff, biome, golangci-lint)"]
     D --> E["Validators run (security, python-style, etc.)"]
@@ -34,13 +34,15 @@ flowchart TD
 /plugin install pragma@claude-pragma
 
 # Then in any project:
-/pragma:setup-project
+/setup-project
 ```
 
-### Example: Using /pragma:implement
+> **Note:** Skills are shown as `/star-chamber (pragma)` in the CLI autocomplete. The short form `/star-chamber` is the easiest way to invoke them. The fully-qualified form `/pragma:star-chamber` also works.
+
+### Example: Using /implement
 
 ```bash
-> /pragma:implement add input validation to the login form
+> /implement add input validation to the login form
 
 [Phase 0] Injecting rules from:
   - .claude/CLAUDE.md (universal)
@@ -68,9 +70,9 @@ flowchart TD
 
 | Skill | What it does | Why it matters |
 |-------|--------------|----------------|
-| `/pragma:setup-project` | Detects languages, creates CLAUDE.md files, configures validators | One command to configure any project |
-| `/pragma:implement <task>` | Implements with automatic validation loop | Catches issues before you review the code |
-| `/pragma:review` | Validates current changes against all rules | Quick check before committing |
+| `/setup-project` | Detects languages, creates CLAUDE.md files, configures validators | One command to configure any project |
+| `/implement <task>` | Implements with automatic validation loop | Catches issues before you review the code |
+| `/review` | Validates current changes against all rules | Quick check before committing |
 
 ### Validators
 
@@ -78,12 +80,12 @@ Validators are semantic checks that run after linters pass. They enforce languag
 
 | Skill | Language | What it checks |
 |-------|----------|----------------|
-| `/pragma:validate` | All | Orchestrator - runs all applicable validators |
-| `/pragma:security` | All | Secrets, injection vulnerabilities, path traversal, auth gaps |
-| `/pragma:python-style` | Python | Google docstrings, type hints, exception chaining, layered architecture |
-| `/pragma:typescript-style` | TypeScript | Strict mode, React patterns, proper hooks, state management |
-| `/pragma:go-effective` | Go | Effective Go rules - naming, error handling, interface design |
-| `/pragma:go-proverbs` | Go | Go Proverbs - idiomatic patterns, concurrency, "clear is better than clever" |
+| `/validate` | All | Orchestrator - runs all applicable validators |
+| `/security` | All | Secrets, injection vulnerabilities, path traversal, auth gaps |
+| `/python-style` | Python | Google docstrings, type hints, exception chaining, layered architecture |
+| `/typescript-style` | TypeScript | Strict mode, React patterns, proper hooks, state management |
+| `/go-effective` | Go | Effective Go rules - naming, error handling, interface design |
+| `/go-proverbs` | Go | Go Proverbs - idiomatic patterns, concurrency, "clear is better than clever" |
 
 ### Advisory Skills
 
@@ -91,13 +93,13 @@ Advisory skills provide feedback but don't block completion.
 
 | Skill | What it does |
 |-------|--------------|
-| `/pragma:star-chamber` | Fans out code review to multiple LLMs (OpenAI, Anthropic, Gemini) and aggregates consensus feedback |
+| `/star-chamber` | Fans out code review to multiple LLMs (OpenAI, Anthropic, Gemini) and aggregates consensus feedback |
 
 ## Validator Severity Levels
 
 | Level | Meaning | What happens |
 |-------|---------|--------------|
-| **HARD** | Must fix | Blocks `/pragma:implement` completion |
+| **HARD** | Must fix | Blocks `/implement` completion |
 | **SHOULD** | Fix or justify | Requires explicit justification to proceed |
 | **WARN** | Advisory | Noted in output but doesn't block |
 
@@ -106,14 +108,14 @@ Advisory skills provide feedback but don't block completion.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `STAR_CHAMBER_CONFIG` | No | Custom path to star-chamber config (default: `~/.config/star-chamber/providers.json`) |
-| `ANY_LLM_KEY` | For `/pragma:star-chamber` | Platform key from [any-llm.ai](https://any-llm.ai) |
-| `OPENAI_API_KEY` | For `/pragma:star-chamber` | OpenAI API key (if not using any-llm.ai) |
-| `ANTHROPIC_API_KEY` | For `/pragma:star-chamber` | Anthropic API key (if not using any-llm.ai) |
-| `GEMINI_API_KEY` | For `/pragma:star-chamber` | Google Gemini API key (if not using any-llm.ai) |
+| `ANY_LLM_KEY` | For `/star-chamber` | Platform key from [any-llm.ai](https://any-llm.ai) |
+| `OPENAI_API_KEY` | For `/star-chamber` | OpenAI API key (if not using any-llm.ai) |
+| `ANTHROPIC_API_KEY` | For `/star-chamber` | Anthropic API key (if not using any-llm.ai) |
+| `GEMINI_API_KEY` | For `/star-chamber` | Google Gemini API key (if not using any-llm.ai) |
 
 ## Monorepo Support
 
-`/pragma:setup-project` detects languages at root AND in subdirectories, creating appropriate CLAUDE.md files for each:
+`/setup-project` detects languages at root AND in subdirectories, creating appropriate CLAUDE.md files for each:
 
 ```text
 myproject/
@@ -153,7 +155,7 @@ claude-pragma/
 
 ## Version Control
 
-**Commit** the generated `.claude/CLAUDE.md` files so other developers get the same rules without re-running `/pragma:setup-project`.
+**Commit** the generated `.claude/CLAUDE.md` files so other developers get the same rules without re-running `/setup-project`.
 
 Claude Code adds `CLAUDE.local.md` to `.gitignore` automatically when it creates the file. If you create it manually, verify it is in your `.gitignore` to avoid committing personal rules.
 

--- a/plugins/pragma/agents/security.md
+++ b/plugins/pragma/agents/security.md
@@ -14,13 +14,13 @@ memory: project
 
 You are a security validator. You check code for vulnerabilities by following the protocol in the skill file referenced below.
 
-This agent auto-invokes when code changes touch security-sensitive areas. For explicit validation as part of the `/pragma:review`, `/pragma:validate`, or `/pragma:implement` pipelines, the skill is used instead.
+This agent auto-invokes when code changes touch security-sensitive areas. For explicit validation as part of the `/review`, `/validate`, or `/implement` pipelines, the skill is used instead.
 
 ## Invocation Policy
 
 - Do NOT invoke for documentation-only or cosmetic changes.
 - Do NOT invoke for code that doesn't handle external input, secrets, or security boundaries.
-- The `/pragma:review`, `/pragma:validate`, and `/pragma:implement` pipelines already include security validation. Duplicate invocation is wasteful but not harmful.
+- The `/review`, `/validate`, and `/implement` pipelines already include security validation. Duplicate invocation is wasteful but not harmful.
 
 ## Input
 

--- a/plugins/pragma/agents/star-chamber.md
+++ b/plugins/pragma/agents/star-chamber.md
@@ -13,12 +13,12 @@ memory: project
 
 You are Star-Chamber, an advisory multi-LLM craftsmanship council. You fan out code reviews and design questions to multiple LLM providers (Claude, OpenAI, Gemini, etc.) and aggregate their feedback into consensus recommendations.
 
-This agent auto-invokes for architectural decisions and runs with isolated context and persistent project memory. For explicit user-requested reviews with live progress, the `/pragma:star-chamber` skill is used instead.
+This agent auto-invokes for architectural decisions and runs with isolated context and persistent project memory. For explicit user-requested reviews with live progress, the `/star-chamber` skill is used instead.
 
 ## Invocation Policy
 
 - Do NOT invoke for routine code changes or well-established patterns.
-- Always use basic mode (no debate) to keep costs predictable. Debate mode is only available via the `/pragma:star-chamber` skill.
+- Always use basic mode (no debate) to keep costs predictable. Debate mode is only available via the `/star-chamber` skill.
 
 ## Path Setup
 

--- a/plugins/pragma/claude-md/languages/go/go.md
+++ b/plugins/pragma/claude-md/languages/go/go.md
@@ -73,6 +73,6 @@
 
 ## Validation Commands
 
-These commands are used by `/pragma:implement` and `/pragma:review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `golangci-lint run --fix -v`

--- a/plugins/pragma/claude-md/languages/python/python.md
+++ b/plugins/pragma/claude-md/languages/python/python.md
@@ -62,6 +62,6 @@ A service that only wraps single CRUD queries with no additional logic is a repo
 
 ## Validation Commands
 
-These commands are used by `/pragma:implement` and `/pragma:review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `uv run pre-commit run --all-files`

--- a/plugins/pragma/claude-md/languages/typescript/typescript.md
+++ b/plugins/pragma/claude-md/languages/typescript/typescript.md
@@ -60,7 +60,7 @@
 
 ## Validation Commands
 
-These commands are used by `/pragma:implement` and `/pragma:review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
+These commands are used by `/implement` and `/review` during validation. Override in `CLAUDE.local.md` if your project uses different scripts.
 
 - **Lint:** `pnpm run lint`
 - **Test:** `pnpm run test`

--- a/plugins/pragma/claude-md/universal/validation-precedence.md
+++ b/plugins/pragma/claude-md/universal/validation-precedence.md
@@ -1,6 +1,6 @@
 # Validation Command Precedence
 
-This document defines the priority order for validation commands used by `/pragma:implement` and `/pragma:review` skills.
+This document defines the priority order for validation commands used by `/implement` and `/review` skills.
 
 ## Priority Order (Highest to Lowest)
 
@@ -52,7 +52,7 @@ Validation commands are configured at the repository root by the setup-project s
 
 Your personal global CLAUDE.md (`~/.claude/CLAUDE.md`) is **separate from this precedence order**. It applies to all Claude Code conversations but has these characteristics:
 
-- **It is NOT merged into generated project rules.** When `/pragma:setup-project` creates `.claude/CLAUDE.md` files, it uses only the claude-pragma templates.
+- **It is NOT merged into generated project rules.** When `/setup-project` creates `.claude/CLAUDE.md` files, it uses only the claude-pragma templates.
 - **It IS visible to validators** because they use `context: fork` and inherit the conversation context.
 - **It MAY cause confusion** if it contains language-specific rules (e.g., Go rules appearing in Python context).
 

--- a/plugins/pragma/skills/implement/SKILL.md
+++ b/plugins/pragma/skills/implement/SKILL.md
@@ -83,7 +83,7 @@ If no project-specific rules were found, attempt to load the universal baseline 
 4. **Load baseline:** If both checks pass, read `$PLUGIN_ROOT/claude-md/universal/base.md` as the baseline rules.
    - Note in report: "Fallback baseline: loaded from pragma plugin"
 
-This fallback ensures projects without `/pragma:setup-project` still get essential rules (branch creation, scope verification, etc.).
+This fallback ensures projects without `/setup-project` still get essential rules (branch creation, scope verification, etc.).
 
 ### Step 4: Record applied rules
 

--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -87,7 +87,7 @@ done
 true
 ```
 
-If any exist, read them. If they have `<!-- Assembled by /pragma:setup-project` comment, safe to overwrite. Otherwise, ask before overwriting.
+If any exist, read them. If they have `<!-- Assembled by /setup-project` comment, safe to overwrite. Otherwise, ask before overwriting.
 
 ## Step 4: Create root .claude/CLAUDE.md
 
@@ -104,9 +104,9 @@ Assemble root CLAUDE.md with:
 
 **Header:**
 ```markdown
-<!-- Assembled by /pragma:setup-project from claude-pragma -->
+<!-- Assembled by /setup-project from claude-pragma -->
 <!-- Org/Repo: {org}/{repo} -->
-<!-- Re-run /pragma:setup-project to regenerate -->
+<!-- Re-run /setup-project to regenerate -->
 ```
 
 **Meta-rule to include after universal rules:**
@@ -179,10 +179,10 @@ Assemble with:
 
 **Header:**
 ```markdown
-<!-- Assembled by /pragma:setup-project from claude-pragma -->
+<!-- Assembled by /setup-project from claude-pragma -->
 <!-- Subdirectory: {subdir} -->
 <!-- Languages: {lang} -->
-<!-- Re-run /pragma:setup-project to regenerate -->
+<!-- Re-run /setup-project to regenerate -->
 ```
 
 ## Step 6: Verify plugin skills and agents
@@ -225,7 +225,7 @@ Check if star-chamber config exists:
 If missing **and `uv` is available** (from the Step 6 check), offer to set it up. If `uv` is missing, skip this offer and tell the user: "Skipping star-chamber config — `uv` is not installed." The Step 8 output includes install instructions.
 
 ```
-/pragma:star-chamber requires provider configuration for multi-LLM reviews.
+/star-chamber requires provider configuration for multi-LLM reviews.
 
 Would you like to set up the configuration?
 
@@ -278,7 +278,7 @@ Then include in the summary:
 
 **If user declines setup**, note in summary:
 ```
-**Star-Chamber:** Not configured (run /pragma:star-chamber to set up later)
+**Star-Chamber:** Not configured (run /star-chamber to set up later)
 ```
 
 ## Step 8: Output summary
@@ -299,25 +299,25 @@ Then include in the summary:
   - frontend/.claude/CLAUDE.md (TypeScript rules)
 
 **Skills available (via pragma plugin):**
-  - /pragma:implement - implement with auto-validation
-  - /pragma:review - review changes against all validators
-  - /pragma:validate - run all validators
-  - /pragma:star-chamber - multi-LLM advisory council
+  - /implement - implement with auto-validation
+  - /review - review changes against all validators
+  - /validate - run all validators
+  - /star-chamber - multi-LLM advisory council
 
 **Agents available (via pragma plugin):**
   - security - auto-invokes on trust boundary changes
   - star-chamber - auto-invokes on architectural decisions
 
 **Usage:**
-  /pragma:implement <task>    - implement with validation loop
-  /pragma:review              - validate current changes
+  /implement <task>    - implement with validation loop
+  /review              - validate current changes
 
-Run `/pragma:star-chamber` for usage details and options.
+Run `/star-chamber` for usage details and options.
 ```
 
 **If uv is missing**, include this warning:
 ```text
-⚠️  **Warning:** uv is not installed. /pragma:star-chamber requires uv to run.
+⚠️  **Warning:** uv is not installed. /star-chamber requires uv to run.
 
 Install uv:
   curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -1,7 +1,7 @@
 # Star-Chamber Protocol
 
 <!-- Single source of truth for the star-chamber review protocol.
-     Referenced by both skills/star-chamber/SKILL.md (explicit /pragma:star-chamber)
+     Referenced by both skills/star-chamber/SKILL.md (explicit /star-chamber)
      and agents/star-chamber.md (auto-invocation).
      Both consumers set $STAR_CHAMBER_PATH before following this protocol. -->
 
@@ -106,7 +106,7 @@ Edit the config to remove providers you don't have keys for.
 **If user chooses "Skip":**
 
 ```
-To set up manually later, see the Configuration section below or run /pragma:star-chamber again.
+To set up manually later, see the Configuration section below or run /star-chamber again.
 ```
 
 **STOP if config is missing. Do not proceed without configuration.**
@@ -424,19 +424,19 @@ Issues raised by a single provider. May be valid specialized insights.
 
 ```bash
 # Basic - review recent changes with default providers (parallel, single round).
-/pragma:star-chamber
+/star-chamber
 
 # Specific files and providers.
-/pragma:star-chamber --file backend/app/auth.py --provider openai --provider anthropic
+/star-chamber --file backend/app/auth.py --provider openai --provider anthropic
 
 # Debate mode - 2 rounds (default) where each provider sees others' responses.
-/pragma:star-chamber --debate
+/star-chamber --debate
 
 # Debate mode - 3 rounds of deliberation.
-/pragma:star-chamber --debate --rounds 3
+/star-chamber --debate --rounds 3
 
 # Debate with specific files.
-/pragma:star-chamber --debate --rounds 2 --file auth.py --provider openai --provider gemini
+/star-chamber --debate --rounds 2 --file auth.py --provider openai --provider gemini
 ```
 
 ## Configuration

--- a/plugins/pragma/skills/star-chamber/SKILL.md
+++ b/plugins/pragma/skills/star-chamber/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Glob, Grep
 
 # Star-Chamber: Multi-LLM Craftsmanship Council
 
-This skill is for explicit `/pragma:star-chamber` invocations with live progress in the main conversation. It supports `--debate` for multi-round deliberation. For automatic invocation on architectural decisions, the `star-chamber` agent handles that separately.
+This skill is for explicit `/star-chamber` invocations with live progress in the main conversation. It supports `--debate` for multi-round deliberation. For automatic invocation on architectural decisions, the `star-chamber` agent handles that separately.
 
 Advisory skill that fans out code reviews and design questions to multiple LLM providers (Claude, OpenAI, Gemini, etc.) and aggregates their feedback into consensus recommendations.
 
@@ -40,4 +40,4 @@ Read and follow the full protocol from `$STAR_CHAMBER_PATH/PROTOCOL.md`. It cont
 
 ## Auto-Invocation
 
-This skill is not auto-invoked (`model-invocable: false`). The `star-chamber` custom subagent handles auto-invocation based on its description. This skill is for explicit `/pragma:star-chamber` invocations only.
+This skill is not auto-invoked (`model-invocable: false`). The `star-chamber` custom subagent handles auto-invocation based on its description. This skill is for explicit `/star-chamber` invocations only.


### PR DESCRIPTION
## Summary

- Plugin skills are invoked as `/star-chamber`, `/implement`, etc. in the CLI — not `/pragma:star-chamber`. The `pragma:` prefix is only used internally by the Skill tool for programmatic dispatch between skills.
- Updated all 72 user-facing references across 13 files to use the short form
- Skill tool dispatch references (`pragma:security`, `pragma:go-effective`, etc.) are unchanged
- Added a note to the README explaining both forms

## Test plan

- [ ] Verify `/star-chamber` works in CLI autocomplete
- [ ] Verify `/implement` works in CLI autocomplete
- [ ] Verify Skill tool dispatch still works (e.g., `/validate` spawning `pragma:go-effective`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated all product documentation to reflect simplified command syntax and improved consistency. All command references have been updated from their previous `/pragma:` prefixed versions to shorter forms: `/setup-project`, `/implement`, `/review`, `/validate`, and `/star-chamber`. Changes span quick-start guides, examples, configuration references, skill documentation, and all user-facing materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->