### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/claude-pragma",


### PR DESCRIPTION
## Summary

- Bump `plugin.json` and `marketplace.json` version from `1.0.0` to `1.1.0`
- This enables users to receive updates via `/plugin update pragma@claude-pragma`

### What's in v1.1.0 (since initial plugin structure)

- Plugin marketplace structure (#51)
- Short-form skill commands — `/star-chamber` instead of `/pragma:star-chamber` (#52)
- PR review feedback fixes (Glob tilde expansion, language tags, contract.json, grammar)

## Test plan

- [ ] Merge and tag `v1.1.0`
- [ ] Create GitHub release from tag
- [ ] Verify `/plugin marketplace update claude-pragma` picks up new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Plugin version updated from 1.0.0 to 1.1.0 across marketplace configuration and plugin manifest files. Version numbers synchronised consistently throughout plugin metadata to maintain proper alignment and tracking across the entire plugin infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->