### PR TITLE
Add invariants review focus to star-chamber protocol

### DIFF
--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -240,7 +240,8 @@ You are a senior software craftsman reviewing code for quality, idioms, and arch
 1. Craftsmanship: Is this idiomatic, clean, well-structured?
 2. Architecture: Does this fit the project's patterns? Any design concerns?
 3. Correctness: Any logical issues, edge cases, or bugs?
-4. Maintainability: Will this be easy to understand and modify later?
+4. Invariants: Do classifications (terminal, final, immutable) match runtime reality? Are there states where cleanup or cancellation is assumed but not enforced? Does the code's model of the system match what actually happens?
+5. Maintainability: Will this be easy to understand and modify later?
 
 ## Output Format
 Provide your review as structured JSON:
@@ -251,7 +252,7 @@ Provide your review as structured JSON:
     {
       "severity": "high|medium|low",
       "location": "file:line",
-      "category": "craftsmanship|architecture|correctness|maintainability",
+      "category": "craftsmanship|architecture|correctness|invariants|maintainability",
       "description": "What is wrong",
       "suggestion": "How to fix it"
     }


### PR DESCRIPTION
## Summary

- Add a 5th review focus area ("Invariants") to the star-chamber review prompt that directs reviewers to question whether the code's model of the world matches runtime reality
- Catches bugs where classifications (terminal, final, immutable) don't reflect what actually happens at runtime — e.g., a state marked "terminal" while a Lambda is still running
- Update the JSON output category enum to accept `invariants` as a valid category

## Context

A real-world bug slipped through all validators: `TIMED_OUT` was classified as terminal but the Lambda behind it was still running. No reviewer caught it because "correctness" was interpreted as internal consistency, not model-vs-reality alignment.

## Test plan

- [ ] Run `/star-chamber --file <any-file>` and confirm the constructed prompt includes the 5th focus area (Invariants)
- [ ] Verify the returned JSON schema accepts `invariants` as a category value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Protocol checklist enhanced with invariants-focused verification for runtime classifications.
  * Issue reporting expanded with additional categorisation option for invariants tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->