### PR TITLE
Fix star-chamber debate mode JSON parse failure

### DIFF
--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -288,7 +288,7 @@ The simplest approach: all providers review independently in a single round.
 Execute a single parallel review. Write the prompt to a temp file first, then pipe it to avoid shell quoting issues:
 
 ```bash
-cat << 'EOF' | uv run --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...] 2>/dev/null
+cat << 'EOF' | uv run --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
 {prompt}
 EOF
 ```


### PR DESCRIPTION
## Summary

- Set `max_tokens` explicitly (8192) in `llm_council.py` to prevent the any-llm-sdk Anthropic provider from emitting a stderr warning that pollutes JSON output

## Context

During debate mode, Round 2 orchestration needs to parse the JSON output from Round 1. The any-llm-sdk Anthropic provider emits a `max_tokens is required` warning to stderr when the parameter is omitted. Claude Code's Bash tool merges stdout+stderr, so this warning appears before the JSON in tool results. The ad-hoc JSON extraction then fails with `JSONDecodeError`.

Setting `max_tokens` explicitly silences the warning at source. A stderr redirect (`2>/dev/null`) was initially included but reverted after review — it would have swallowed real errors from uv, Python tracebacks, and the script's own diagnostics.

## Test plan

- [ ] Run `/star-chamber --debate --rounds 2` and verify Round 2 completes without JSON parse errors
- [ ] Run `/star-chamber` (parallel mode) and verify clean JSON output with no warning prefix
- [ ] Verify Anthropic provider still returns results correctly with explicit `max_tokens`