### PR TITLE
Fix star-chamber provider compatibility and configurable max_tokens

### DIFF
--- a/plugins/pragma/reference/star-chamber/providers.json
+++ b/plugins/pragma/reference/star-chamber/providers.json
@@ -4,19 +4,22 @@
     {
       "provider": "openai",
       "model": "gpt-5.2",
-      "api_key": "${OPENAI_API_KEY}"
+      "api_key": "${OPENAI_API_KEY}",
+      "max_tokens": 128000
     },
     {
       "provider": "anthropic",
       "model": "claude-opus-4-6",
-      "api_key": "${ANTHROPIC_API_KEY}"
+      "api_key": "${ANTHROPIC_API_KEY}",
+      "max_tokens": 8192
     },
     {
       "provider": "gemini",
       "model": "gemini-2.5-flash",
-      "api_key": "${GEMINI_API_KEY}"
+      "api_key": "${GEMINI_API_KEY}",
+      "max_tokens": 65536
     }
   ],
   "consensus_threshold": 2,
-  "timeout_seconds": 60
+  "timeout_seconds": 120
 }

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -24,7 +24,7 @@
 
 ## Runtime Constraint
 
-**Each Bash tool invocation in Claude Code runs in a separate subprocess.** Shell variables do not persist between invocations. `$STAR_CHAMBER_PATH` must be set at the top of every bash block that references it.
+**Each Bash tool invocation in Claude Code runs in a separate subprocess.** Shell variables do not persist between invocations. `$STAR_CHAMBER_PATH` must be set at the top of every bash block that references it. **Use `;` (not `&&`) to chain the assignment with subsequent commands** — `&&` breaks variable propagation in `bash -c` contexts.
 
 `$STAR_CHAMBER_PATH` is set by the caller:
 - **Skill invocation:** The skill loader provides the base directory in the header. The skill sets `STAR_CHAMBER_PATH` to that directory.
@@ -269,7 +269,7 @@ Use `uv run --with <dep>` to execute scripts with ephemeral dependencies. Do not
 First, determine which SDK packages are needed:
 
 ```bash
-uv run --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
+STAR_CHAMBER_PATH="<set by caller>"; uv run --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
 ```
 
 This outputs JSON with `required_sdks` array listing needed packages (e.g., `["anthropic", "google-genai"]`).
@@ -288,7 +288,7 @@ The simplest approach: all providers review independently in a single round.
 Execute a single parallel review. Write the prompt to a temp file first, then pipe it to avoid shell quoting issues:
 
 ```bash
-cat << 'EOF' | uv run --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...] 2>/dev/null
+STAR_CHAMBER_PATH="<set by caller>"; cat << 'EOF' | uv run --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
 {prompt}
 EOF
 ```

--- a/plugins/pragma/skills/star-chamber/test_llm_council.py
+++ b/plugins/pragma/skills/star-chamber/test_llm_council.py
@@ -1,0 +1,79 @@
+"""Tests for llm_council.py."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from llm_council import DEFAULT_MAX_TOKENS, _get_review_internal, run_council
+
+
+def _mock_acompletion():
+    """Create a mock acompletion that returns a valid response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"provider": "test"}'
+    return AsyncMock(return_value=mock_response)
+
+
+class TestMaxTokensPassthrough:
+    """Verify max_tokens from provider config is passed to acompletion."""
+
+    def test_default_max_tokens_passed_to_acompletion(self):
+        """Default max_tokens should be used when provider config omits it."""
+        mock_acompletion = _mock_acompletion()
+        mock_module = MagicMock()
+        mock_module.acompletion = mock_acompletion
+
+        # Use gemini (non-OpenAI) to test the max_tokens path.
+        with patch.dict(sys.modules, {"any_llm": mock_module}):
+            asyncio.run(_get_review_internal("gemini", "gemini-2.5-flash", "test prompt", "key"))
+            assert mock_acompletion.call_args.kwargs.get("max_tokens") == DEFAULT_MAX_TOKENS
+
+    def test_custom_max_tokens_passed_to_acompletion(self):
+        """Provider-specified max_tokens should override the default."""
+        mock_acompletion = _mock_acompletion()
+        mock_module = MagicMock()
+        mock_module.acompletion = mock_acompletion
+
+        with patch.dict(sys.modules, {"any_llm": mock_module}):
+            asyncio.run(_get_review_internal("anthropic", "claude-opus-4-6", "test prompt", "key", max_tokens=8192))
+            assert mock_acompletion.call_args.kwargs.get("max_tokens") == 8192
+
+    def test_openai_uses_max_completion_tokens(self):
+        """OpenAI provider should use max_completion_tokens instead of max_tokens."""
+        mock_acompletion = _mock_acompletion()
+        mock_module = MagicMock()
+        mock_module.acompletion = mock_acompletion
+
+        with patch.dict(sys.modules, {"any_llm": mock_module}):
+            asyncio.run(_get_review_internal("openai", "gpt-5.2", "test prompt", "key", max_tokens=128000))
+            call_kwargs = mock_acompletion.call_args.kwargs
+            assert call_kwargs.get("max_completion_tokens") == 128000
+            assert "max_tokens" not in call_kwargs
+
+    def test_run_council_threads_max_tokens_from_provider(self):
+        """run_council should read max_tokens from provider config and pass it through."""
+        mock_acompletion = _mock_acompletion()
+        mock_module = MagicMock()
+        mock_module.acompletion = mock_acompletion
+
+        providers = [
+            {"provider": "openai", "model": "gpt-5.2", "api_key": "k1", "max_tokens": 128000},
+            {"provider": "gemini", "model": "gemini-2.5-flash", "api_key": "k2", "max_tokens": 65536},
+            {"provider": "anthropic", "model": "claude-opus-4-6", "api_key": "k3"},
+        ]
+
+        with patch.dict(sys.modules, {"any_llm": mock_module}):
+            asyncio.run(run_council("test prompt", providers))
+            # Index calls by provider to avoid order-dependent assertions.
+            calls_by_provider = {
+                c.kwargs["provider"]: c.kwargs
+                for c in mock_acompletion.call_args_list
+            }
+            # openai: explicit 128000 via max_completion_tokens.
+            assert calls_by_provider["openai"].get("max_completion_tokens") == 128000
+            assert "max_tokens" not in calls_by_provider["openai"]
+            # gemini: explicit 65536 via max_tokens.
+            assert calls_by_provider["gemini"].get("max_tokens") == 65536
+            # anthropic: no max_tokens in config, should get default.
+            assert calls_by_provider["anthropic"].get("max_tokens") == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
## Summary

- Make `max_tokens` configurable per provider in `providers.json` config
- Map `max_tokens` → `max_completion_tokens` for OpenAI provider (gpt-5.x rejects `max_tokens`, requires `max_completion_tokens` — upstream issue: https://github.com/mozilla-ai/any-llm/issues/862)
- Set Anthropic `max_tokens` to 8192 (Anthropic SDK hard limit for opus models in non-streaming mode)
- Set OpenAI to 128000, Gemini to 65536 (their actual model maximums)
- Fix shell variable propagation in PROTOCOL.md (`&&` breaks variable assignment in `bash -c` — use `;` instead)
- Bump `timeout_seconds` from 60 to 120
- Add tests for `max_tokens` passthrough and OpenAI parameter mapping

## Context

The original bug was a JSON parse failure in star-chamber debate mode caused by an any-llm-sdk warning (`max_tokens is required for Anthropic`) polluting stdout. Setting `max_tokens` explicitly silences that warning. Live testing then revealed two additional provider-specific issues that are also fixed here.

## Test plan

- [x] All 4 unit tests pass (`test_llm_council.py`)
- [ ] Live test with `/pragma:star-chamber` to verify all 3 providers respond successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum token limits for language model providers with sensible defaults.

* **Improvements**
  * Increased operation timeout from 60 to 120 seconds for enhanced reliability.

* **Documentation**
  * Updated protocol documentation to clarify environment variable handling in shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->