### PR TITLE
Bump plugin version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/claude-pragma",


### PR DESCRIPTION
## Summary

- Bump marketplace and plugin metadata version from 1.0.0 to 1.1.0

## Changes since 1.0.0

- Configurable per-provider `max_tokens` for star-chamber LLM council
- OpenAI `max_completion_tokens` mapping workaround (gpt-5.x compatibility)
- Anthropic `max_tokens` set to 8192 (SDK non-streaming limit for opus models)
- Shell variable propagation fix in PROTOCOL.md (`;` vs `&&` in `bash -c`)
- Global timeout bumped to 120s
- State-machine validator for lifecycle correctness
- State-model scrutiny guard (implement Phase 1)
- Invariants review focus added to star-chamber protocol
- Unit tests for max_tokens passthrough and provider param mapping

## After merge

Tag `v1.1.0` and create GitHub release.