### PR TITLE
Fix setup-project building go-structural for non-Go projects

### DIFF
--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -196,7 +196,12 @@ command -v uv >/dev/null 2>&1 && echo "uv:ok" || echo "uv:missing"
 
 Store the result - if `uv:missing`, include a warning in Step 8 output.
 
-**Go (if detected anywhere) — build go-structural:**
+**Build go-structural (ONLY if Go was detected in Step 2):**
+
+Skip this entirely if no `go` language was detected in Step 2 output (e.g. if the only output was `root:python`, there is no Go — do not build go-structural).
+
+If and only if Go was detected (any line matching `*:go` in Step 2 output):
+
 ```bash
 cd "$PLUGIN_ROOT/tools/go-structural" && go build -o go-structural . && echo "go-structural:ok" || echo "go-structural:build-failed"
 ```


### PR DESCRIPTION
## Summary

- **Bug:** Running `/setup-project` in a Python-only repo still built `go-structural`, because the conditional in Step 6 was a weak parenthetical hint in the heading (`**Go (if detected anywhere) — build go-structural:**`). The executing agent didn't reliably gate on this soft natural-language condition — it saw the build command, checked that `go` was installed on the machine, and proceeded to build regardless of the Step 2 language detection output.
- **Fix:** Replaced the parenthetical hint with explicit, unambiguous gating language that makes the condition structural and impossible to miss: "Skip this entirely if no `go` language was detected in Step 2 output" with a concrete example, plus "If and only if Go was detected (any line matching `*:go` in Step 2 output)".

## Test plan

- [ ] Run `/setup-project` in a Python-only repo and verify go-structural is not built
- [ ] Run `/setup-project` in a Go repo and verify go-structural is still built
- [ ] Run `/setup-project` in a monorepo with a Go subdirectory and verify go-structural is built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Enhanced setup-project documentation with improved conditional build instructions. Users now receive clearer guidance on which build steps to execute based on detected programming languages from earlier project setup stages, including explicit instructions for skipping steps when specific detection conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->