### PR TITLE
Fix implement skill dumping raw validator JSON instead of summary

### DIFF
--- a/plugins/pragma/skills/implement/SKILL.md
+++ b/plugins/pragma/skills/implement/SKILL.md
@@ -175,7 +175,8 @@ After implementation is complete, run validation.
    Fix any issues before proceeding.
 
 2. **Run semantic validators** (LLM checks):
-   - Use the Task tool to spawn validators in parallel. For each, use the Skill tool to invoke the validator and return its JSON output verbatim.
+   - Use the Task tool to spawn each validator in parallel. Each subagent should invoke the validator via the Skill tool and return the JSON result back to you (the parent).
+   - **Collect all validator JSON results internally.** Do NOT display raw validator JSON to the user — you will aggregate these results into the Phase 4 summary.
    - Note: This duplicates the dispatch logic in `pragma:validate` intentionally — implement needs inline control for the fix-and-re-validate loop. Keep both in sync.
      - `pragma:security` (always)
      - `pragma:state-machine` (always)
@@ -190,6 +191,8 @@ After implementation is complete, run validation.
    - WARN: note but don't block.
 
 4. **Re-validate** if fixes were made.
+
+5. **After all validators pass, proceed to Phase 4.** Do not stop here — the final output must be the Phase 4 summary, not raw validator output.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Bug:** After the implement skill finished running validators in Phase 3, it displayed raw security validator JSON to the user and stopped — never producing the Phase 4 aggregated summary (task, branch, rules applied, changes, validation results).
- **Root cause:** Phase 3 Step 2 instructed "use the Skill tool to invoke the validator and return its JSON output verbatim." This was intended to tell subagents to pass JSON back to the parent agent, but the parent interpreted "verbatim" as "show the raw JSON to the user" and treated it as the final output. There was also no explicit instruction bridging Phase 3 to Phase 4.
- **Fix:** Three changes to Phase 3:
  1. Clarified subagent instruction: "return the JSON result back to you (the parent)" — makes the audience unambiguous.
  2. Added explicit gate: "Collect all validator JSON results internally. Do NOT display raw validator JSON to the user."
  3. Added Step 5: "After all validators pass, proceed to Phase 4" — ensures the agent always produces the full implementation summary.

## Test plan

- [ ] Run `/implement` on a Python project and verify the final output is the Phase 4 markdown summary (not raw JSON)
- [ ] Verify the summary includes all sections: Task, Branch, Rules Applied, Changes, Validation results
- [ ] Verify validator results are aggregated into the Validation section with pass/fail status per validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified validation workflow documentation to specify parallel validator execution and result aggregation across phases.
  * Improved guidance on how validation results are processed and presented without displaying raw JSON output to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->