### PR TITLE
Fix security and go-proverbs validators emitting prose after JSON

### DIFF
--- a/plugins/pragma/skills/go-proverbs/SKILL.md
+++ b/plugins/pragma/skills/go-proverbs/SKILL.md
@@ -139,7 +139,7 @@ If WebFetch fails, use this list:
 
 ## Step 5: Report
 
-Output MUST follow this JSON schema:
+Output MUST follow this JSON schema exactly. Do not include prose outside the JSON.
 
 ```json
 {

--- a/plugins/pragma/skills/security/SKILL.md
+++ b/plugins/pragma/skills/security/SKILL.md
@@ -96,7 +96,7 @@ If more than 50 files changed, process in batches of 50. Note batch number in ou
 
 ## Step 3: Report
 
-Output MUST follow this JSON schema (unified with other validators):
+Output MUST follow this JSON schema exactly. Do not include prose outside the JSON.
 
 ```json
 {


### PR DESCRIPTION
## Summary

- **Bug:** The security validator appended a human-readable "Analysis:" section after its JSON output, which contributed to the parent implement skill displaying raw validator output instead of aggregating into the Phase 4 summary.
- **Root cause:** The `security` and `go-proverbs` validators were missing the "Do not include prose outside the JSON" constraint that the other four validators (`go-effective`, `python-style`, `typescript-style`, `state-machine`) already had. Without this explicit constraint, the LLM added helpful but contract-violating commentary after the JSON.
- **Fix:** Aligned both validators with the existing convention: `Output MUST follow this JSON schema exactly. Do not include prose outside the JSON.`

## Test plan

- [ ] Run `pragma:security` and verify output is JSON only, no trailing prose
- [ ] Run `pragma:go-proverbs` on a Go project and verify output is JSON only
- [ ] Run `/implement` end-to-end and verify validator results are aggregated into the Phase 4 summary (works with #61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated instruction requirements for Go Proverbs and Security skills to enforce strict JSON schema compliance, prohibiting prose or commentary outside JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->