### PR TITLE
Fix star-chamber using host project dependencies via uv run

### DIFF
--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -243,7 +243,7 @@ How would you like to manage API keys?
 
 **If user chooses "any-llm.ai platform":**
 ```bash
-uv run python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then include in the summary:
@@ -260,7 +260,7 @@ Then include in the summary:
 
 **If user chooses "Direct provider keys":**
 ```bash
-uv run python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then include in the summary:

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -70,7 +70,7 @@ How would you like to manage API keys?
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then show:
@@ -88,7 +88,7 @@ Setup:
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then show:
@@ -264,12 +264,12 @@ Provide your review as structured JSON:
 
 ## Step 4: Fan Out to Star-Chamber
 
-Use `uv run --with <dep>` to execute scripts with ephemeral dependencies. Do not use `uvx` — it runs CLI tools from PyPI (similar to `npx`), not project scripts with local file paths.
+Use `uv run --no-project --with <dep>` to execute scripts with ephemeral dependencies, isolated from the host project's environment. The `--no-project` flag is critical — without it, `uv` discovers the host project's `pyproject.toml` and includes its dependencies, which can cause version conflicts. Do not use `uvx` — it runs CLI tools from PyPI (similar to `npx`), not project scripts with local file paths.
 
 First, determine which SDK packages are needed:
 
 ```bash
-STAR_CHAMBER_PATH="<set by caller>"; uv run --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
+STAR_CHAMBER_PATH="<set by caller>"; uv run --no-project --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
 ```
 
 This outputs JSON with `required_sdks` array listing needed packages (e.g., `["anthropic", "google-genai"]`).
@@ -288,7 +288,7 @@ The simplest approach: all providers review independently in a single round.
 Execute a single parallel review. Write the prompt to a temp file first, then pipe it to avoid shell quoting issues:
 
 ```bash
-STAR_CHAMBER_PATH="<set by caller>"; cat << 'EOF' | uv run --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
+STAR_CHAMBER_PATH="<set by caller>"; cat << 'EOF' | uv run --no-project --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
 {prompt}
 EOF
 ```


### PR DESCRIPTION
## Summary

- **Bug:** When star-chamber ran inside a Python project (e.g. `any-llm`), all three providers failed with a `client_name` error. The `uv run --with any-llm-sdk` command was discovering the host project's `pyproject.toml` and including its dependencies alongside the `--with` packages. The project had `any-llm-platform-client==0.2.0` installed, which conflicted with what the SDK needed (`>=0.3.0`).
- **Root cause:** `uv run` without `--no-project` merges the host project's dependency tree with the `--with` packages. Star-chamber's scripts are standalone plugin tools that should never depend on or be contaminated by the host project's environment.
- **Fix:** Added `--no-project` to all 6 `uv run` invocations that execute plugin scripts:
  - PROTOCOL.md: 4 invocations (2x `generate_config.py`, `--list-sdks`, main `llm_council.py`)
  - setup-project/SKILL.md: 2 invocations (2x `generate_config.py`)
  - Updated the explanatory text in PROTOCOL.md to document why `--no-project` is critical

## Test plan

- [ ] Run `/star-chamber` from within a Python project that has its own `pyproject.toml` and verify providers connect successfully
- [ ] Run `/setup-project` and choose star-chamber config setup — verify `generate_config.py` runs without picking up host project deps
- [ ] Verify `--list-sdks` output is clean (no warnings about conflicting versions)