### PR TITLE
Fix uv run leaking host .venv packages despite --no-project

### DIFF
--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -248,7 +248,7 @@ How would you like to manage API keys?
 
 **If user chooses "any-llm.ai platform":**
 ```bash
-uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then include in the summary:
@@ -265,7 +265,7 @@ Then include in the summary:
 
 **If user chooses "Direct provider keys":**
 ```bash
-uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then include in the summary:

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -70,7 +70,7 @@ How would you like to manage API keys?
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then show:
@@ -88,7 +88,7 @@ Setup:
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then show:
@@ -264,12 +264,12 @@ Provide your review as structured JSON:
 
 ## Step 4: Fan Out to Star-Chamber
 
-Use `uv run --no-project --with <dep>` to execute scripts with ephemeral dependencies, isolated from the host project's environment. The `--no-project` flag is critical — without it, `uv` discovers the host project's `pyproject.toml` and includes its dependencies, which can cause version conflicts. Do not use `uvx` — it runs CLI tools from PyPI (similar to `npx`), not project scripts with local file paths.
+Use `uv run --no-project --isolated --with <dep>` to execute scripts with ephemeral dependencies, fully isolated from the host project's environment. The `--no-project` flag prevents `uv` from discovering the host project's `pyproject.toml`. The `--isolated` flag prevents `uv` from reusing an active virtual environment (via `VIRTUAL_ENV`) or a `.venv` directory found in the current or parent directories — without it, host project packages leak into `sys.path` even with `--no-project`. Do not use `uvx` — it runs CLI tools from PyPI (similar to `npx`), not project scripts with local file paths.
 
 First, determine which SDK packages are needed:
 
 ```bash
-STAR_CHAMBER_PATH="<set by caller>"; uv run --no-project --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
+STAR_CHAMBER_PATH="<set by caller>"; uv run --no-project --isolated --with any-llm-sdk python "$STAR_CHAMBER_PATH/llm_council.py" --list-sdks
 ```
 
 This outputs JSON with `required_sdks` array listing needed packages (e.g., `["anthropic", "google-genai"]`).
@@ -288,7 +288,7 @@ The simplest approach: all providers review independently in a single round.
 Execute a single parallel review. Write the prompt to a temp file first, then pipe it to avoid shell quoting issues:
 
 ```bash
-STAR_CHAMBER_PATH="<set by caller>"; cat << 'EOF' | uv run --no-project --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
+STAR_CHAMBER_PATH="<set by caller>"; cat << 'EOF' | uv run --no-project --isolated --with any-llm-sdk [--with <sdk>...] python "$STAR_CHAMBER_PATH/llm_council.py" [--provider <name>...] [--file <path>...]
 {prompt}
 EOF
 ```


### PR DESCRIPTION
## Summary

- `--no-project` only prevents `pyproject.toml` discovery — it does **not** prevent `uv` from reusing an active virtual environment (`VIRTUAL_ENV`) or a `.venv` directory in the current/parent directories
- When running in a Python project with a `.venv`, host project packages leak into `sys.path`, causing dependency conflicts with the ephemeral `--with` packages
- Add `--isolated` flag to all `uv run --no-project` invocations across star-chamber PROTOCOL and setup-project SKILL to force a completely fresh environment

## Test plan

- [ ] Run `/star-chamber` from a Python project root that has a `pyproject.toml` and `.venv` with installed dependencies
- [ ] Verify `sys.path` in the uv subprocess no longer contains the host `.venv/lib/.../site-packages`
- [ ] Run `/setup-project` and verify star-chamber config generation still works with `--isolated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated setup and project configuration documentation to clarify environment isolation requirements during Python script execution.
- Enhanced step-by-step guidance for initialisation procedures across both platform and direct provider configuration flows, ensuring more reliable and consistent project setup whilst minimising host environment interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->