### PR TITLE
Rename claude-pragma to agent-pragma

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "claude-pragma",
+  "name": "agent-pragma",
   "owner": { "name": "Peter Wilson" },
   "metadata": {
-    "description": "Pragma directives for Claude Code — deterministic linting, semantic LLM validators, and multi-LLM advisory council for Go, Python, and TypeScript"
+    "description": "Pragma directives for AI coding agents — deterministic linting, semantic LLM validators, and multi-LLM advisory council for Go, Python, and TypeScript"
   },
   "plugins": [
     {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document explains the design decisions behind claude-pragma.
+This document explains the design decisions behind agent-pragma.
 
 ## User Flow: End-to-End
 
@@ -9,7 +9,7 @@ This diagram shows the complete workflow from project setup through implementati
 ```mermaid
 flowchart TB
     subgraph Setup["One-Time Setup"]
-        S1["Clone claude-pragma repo"]
+        S1["Clone agent-pragma repo"]
         S2["Install pragma plugin"]
         S3["Run /setup-project"]
         S1 --> S2 --> S3

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ AGENT ?= claude
 .DEFAULT_GOAL := help
 
 help:
-	@echo "claude-pragma - Pragma directives for Claude Code (and OpenCode)"
+	@echo "agent-pragma - Pragma directives for AI coding agents"
 	@echo ""
 	@echo "Claude Code (recommended):"
-	@echo "  /plugin marketplace add peteski22/claude-pragma"
-	@echo "  /plugin install pragma@claude-pragma"
+	@echo "  /plugin marketplace add peteski22/agent-pragma"
+	@echo "  /plugin install pragma@agent-pragma"
 	@echo ""
 	@echo "OpenCode:"
 	@echo "  make install AGENT=opencode                        Install globally (~/.config/opencode/)"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Claude Pragma
+# Agent Pragma
 
 **The problem:** AI coding agents follow rules inconsistently. Rules get forgotten mid-conversation, ignored during complex tasks, or applied partially. There's no enforcement mechanism.
 
-**The solution:** claude-pragma provides skills that mechanically inject rules and validate compliance. Rules aren't remembered - they're enforced by validators that run automatically on every implementation.
+**The solution:** agent-pragma provides skills that mechanically inject rules and validate compliance. Rules aren't remembered - they're enforced by validators that run automatically on every implementation.
 
 **Works with both [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenCode](https://opencode.ai).**
 
@@ -32,8 +32,8 @@ flowchart TD
 
 ```bash
 # Install the plugin from the marketplace
-/plugin marketplace add peteski22/claude-pragma
-/plugin install pragma@claude-pragma
+/plugin marketplace add peteski22/agent-pragma
+/plugin install pragma@agent-pragma
 
 # Then in any project:
 /setup-project
@@ -45,8 +45,8 @@ flowchart TD
 
 ```bash
 # Clone the repo
-git clone https://github.com/peteski22/claude-pragma.git
-cd claude-pragma
+git clone https://github.com/peteski22/agent-pragma.git
+cd agent-pragma
 
 # Install globally (skills, agents, and commands available in all sessions)
 make install AGENT=opencode
@@ -159,7 +159,7 @@ When you edit `backend/app/main.py`, both the Python rules and universal rules a
 ## Directory Structure
 
 ```text
-claude-pragma/
+agent-pragma/
 ├── .claude-plugin/
 │   └── marketplace.json        # Claude Code marketplace catalog
 ├── plugins/
@@ -205,7 +205,7 @@ make uninstall
 ## More Information
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) - Design decisions, validator contracts, system flow diagrams
-- [Issues](https://github.com/peteski22/claude-pragma/issues) - Bug reports and feature requests
+- [Issues](https://github.com/peteski22/agent-pragma/issues) - Bug reports and feature requests
 
 ## License
 

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
-  "repository": "https://github.com/peteski22/claude-pragma",
+  "repository": "https://github.com/peteski22/agent-pragma",
   "license": "Apache-2.0",
   "keywords": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
 }

--- a/plugins/pragma/agents/security.md
+++ b/plugins/pragma/agents/security.md
@@ -53,8 +53,8 @@ Discover the security skill file via Glob under the plugin cache:
 Security skill file not found. The pragma plugin may not be installed correctly.
 
 Install the plugin:
-  /plugin marketplace add peteski22/claude-pragma
-  /plugin install pragma@claude-pragma
+  /plugin marketplace add peteski22/agent-pragma
+  /plugin install pragma@agent-pragma
 ```
 
 **STOP if not found. Do not proceed.**

--- a/plugins/pragma/agents/star-chamber.md
+++ b/plugins/pragma/agents/star-chamber.md
@@ -47,8 +47,8 @@ Discover the star-chamber protocol file via Glob under the plugin cache:
 Star-chamber protocol file not found. The pragma plugin may not be installed correctly.
 
 Install the plugin:
-  /plugin marketplace add peteski22/claude-pragma
-  /plugin install pragma@claude-pragma
+  /plugin marketplace add peteski22/agent-pragma
+  /plugin install pragma@agent-pragma
 ```
 
 **STOP if not found. Do not proceed.**

--- a/plugins/pragma/claude-md/universal/validation-precedence.md
+++ b/plugins/pragma/claude-md/universal/validation-precedence.md
@@ -52,7 +52,7 @@ Validation commands are configured at the repository root by the setup-project s
 
 Your personal global CLAUDE.md (`~/.claude/CLAUDE.md`) is **separate from this precedence order**. It applies to all Claude Code conversations but has these characteristics:
 
-- **It is NOT merged into generated project rules.** When `/setup-project` creates `.claude/CLAUDE.md` files, it uses only the claude-pragma templates.
+- **It is NOT merged into generated project rules.** When `/setup-project` creates `.claude/CLAUDE.md` files, it uses only the agent-pragma templates.
 - **It IS visible to validators** because they use `context: fork` and inherit the conversation context.
 - **It MAY cause confusion** if it contains language-specific rules (e.g., Go rules appearing in Python context).
 

--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -34,8 +34,8 @@ true
 Plugin root could not be resolved. The pragma plugin may not be installed correctly.
 
 Reinstall:
-  /plugin marketplace add peteski22/claude-pragma
-  /plugin install pragma@claude-pragma
+  /plugin marketplace add peteski22/agent-pragma
+  /plugin install pragma@agent-pragma
 ```
 
 **STOP if check fails. Do not proceed.**
@@ -104,7 +104,7 @@ Assemble root CLAUDE.md with:
 
 **Header:**
 ```markdown
-<!-- Assembled by /setup-project from claude-pragma -->
+<!-- Assembled by /setup-project from agent-pragma -->
 <!-- Org/Repo: {org}/{repo} -->
 <!-- Re-run /setup-project to regenerate -->
 ```
@@ -122,7 +122,7 @@ For example:
 Always apply the most specific rules available for the code you're working on.
 
 <!-- NOTE: This section intentionally mirrors claude-md/universal/context-aware.md.
-     Generated files must be standalone (users' repos can't reference claude-pragma).
+     Generated files must be standalone (users' repos can't reference agent-pragma).
      Update both files together if this guidance changes. -->
 ## Local Supplements
 
@@ -179,7 +179,7 @@ Assemble with:
 
 **Header:**
 ```markdown
-<!-- Assembled by /setup-project from claude-pragma -->
+<!-- Assembled by /setup-project from agent-pragma -->
 <!-- Subdirectory: {subdir} -->
 <!-- Languages: {lang} -->
 <!-- Re-run /setup-project to regenerate -->

--- a/plugins/pragma/tools/go-structural/.golangci.yaml
+++ b/plugins/pragma/tools/go-structural/.golangci.yaml
@@ -35,7 +35,7 @@ formatters:
       sections:
       - standard # Standard section: captures all standard packages.
       - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/peteski22/claude-pragma) # Custom section: groups all imports with the specified Prefix.
+      - prefix(github.com/peteski22/agent-pragma) # Custom section: groups all imports with the specified Prefix.
       - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
       - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
       #- alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.

--- a/plugins/pragma/tools/go-structural/checks/checks_test.go
+++ b/plugins/pragma/tools/go-structural/checks/checks_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/peteski22/claude-pragma/tools/go-structural/checks"
+	"github.com/peteski22/agent-pragma/tools/go-structural/checks"
 )
 
 // parseTestFile parses a testdata fixture and runs all checks against it.

--- a/plugins/pragma/tools/go-structural/go.mod
+++ b/plugins/pragma/tools/go-structural/go.mod
@@ -1,4 +1,4 @@
-module github.com/peteski22/claude-pragma/tools/go-structural
+module github.com/peteski22/agent-pragma/tools/go-structural
 
 go 1.25.7
 

--- a/plugins/pragma/tools/go-structural/main.go
+++ b/plugins/pragma/tools/go-structural/main.go
@@ -18,7 +18,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/peteski22/claude-pragma/tools/go-structural/checks"
+	"github.com/peteski22/agent-pragma/tools/go-structural/checks"
 )
 
 // version is the semantic version of go-structural.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,8 +264,8 @@ case "${ACTION}" in
     install)
         if [[ "${AGENT}" == "claude" ]]; then
             echo "WARNING: Legacy install is deprecated. Use the plugin marketplace instead:"
-            echo "  /plugin marketplace add peteski22/claude-pragma"
-            echo "  /plugin install pragma@claude-pragma"
+            echo "  /plugin marketplace add peteski22/agent-pragma"
+            echo "  /plugin install pragma@agent-pragma"
             echo ""
         fi
         echo "Installing pragma for ${AGENT} (${target})..."


### PR DESCRIPTION
## Summary

- Renames all internal references from `claude-pragma` to `agent-pragma` across 14 files
- Updates Go module paths, plugin manifests, install commands, agent docs, skill templates, and documentation
- Prepares for GitHub repo rename from `peteski22/claude-pragma` to `peteski22/agent-pragma`

The project now supports multiple AI coding agents (Claude Code, OpenCode) so the name should be tool-agnostic.

**Note:** The actual GitHub repo rename (Settings > General > Repository name) should be done separately — either before or after merging this PR.

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded product from Claude Pragma to Agent Pragma across all documentation, installation guides, and marketplace references.
  * Updated repository URLs and installation commands to reflect the new product name throughout configuration files and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->