### PR TITLE
Bump plugin version to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",


### PR DESCRIPTION
## Summary

- Bumps plugin version from 1.1.1 to 2.0.0 in `marketplace.json` and `plugin.json`

Major version bump covering:
- **Breaking:** Repository renamed from `claude-pragma` to `agent-pragma` — existing install commands (`pragma@claude-pragma`) no longer work
- **Feature:** OpenCode support added (skills, agents, commands, install script)

## Test plan

- [ ] Verify plugin installs with `/plugin marketplace add peteski22/agent-pragma`
- [ ] Verify `/plugin install pragma@agent-pragma` works