### PR TITLE
Clarify validator dispatch in implement Phase 3

### DIFF
--- a/plugins/pragma/skills/implement/SKILL.md
+++ b/plugins/pragma/skills/implement/SKILL.md
@@ -175,7 +175,7 @@ After implementation is complete, run validation.
    Fix any issues before proceeding.
 
 2. **Run semantic validators** (LLM checks):
-   - Use the Task tool to spawn validators in parallel. For each validator, create a Task with `subagent_type: "general-purpose"` and a prompt instructing the subagent to invoke the validator skill (e.g., `pragma:security`) via the Skill tool and return the JSON result verbatim.
+   - Use the Task tool to spawn validators in parallel. For each validator, create a Task with `subagent_type: "general-purpose"` and a prompt instructing the subagent to invoke the validator skill via the Skill tool (e.g., `skill: "security"`) and return the JSON result verbatim.
    - Do NOT use validator names as the `subagent_type` — most validators are skills, not agents. Always use `general-purpose` as the subagent type.
    - **Collect all validator JSON results internally.** Do NOT display raw validator JSON to the user — you will aggregate these results into the Phase 4 summary.
    - Note: This duplicates the dispatch logic in `validate` intentionally — implement needs inline control for the fix-and-re-validate loop. Keep both in sync.


### PR DESCRIPTION
## Summary
- Explicitly specify `subagent_type: general-purpose` for validator Task spawning
- Add `Do NOT use validator names as the subagent_type` constraint
- Only `pragma:security` and `pragma:star-chamber` exist as agent types; the rest are skills only

## Test plan
- [ ] Run `/implement` on a task with Go files — verify validators spawn as general-purpose subagents invoking skills

Fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved semantic validator execution architecture to enhance consistency and reliability of validation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->