### PR TITLE
Strengthen wording for uncommitted changes handling

### DIFF
--- a/plugins/pragma/claude-md/universal/base.md
+++ b/plugins/pragma/claude-md/universal/base.md
@@ -32,7 +32,12 @@ git checkout -b <prefix>/<short-description>
 
 **If not in a git repository**, skip git steps and note in report.
 
-**If there are uncommitted changes**, ask the user: stash, commit, or continue?
+**If there are uncommitted changes**, you MUST ask the user before proceeding. Present these options:
+- Stash the changes
+- Commit the changes first
+- Continue with uncommitted changes in the working tree
+
+Do NOT stash, commit, or discard uncommitted changes without explicit user approval.
 
 **If in detached HEAD state**, ask user whether to create a branch from current commit.
 


### PR DESCRIPTION
## Summary
- The pre-implementation setup rule said 'ask the user: stash, commit, or continue?' but the model ignored it and silently stashed
- Changed to MUST language with explicit Do NOT constraint
- Affects `plugins/pragma/claude-md/universal/base.md` line 35

## Test plan
- [ ] Run `/implement` with uncommitted changes present — verify it asks before acting

Fixes #76