### PR TITLE
Reframe setup-project commit guidance as suggestion

### DIFF
--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -333,6 +333,6 @@ Or see: https://docs.astral.sh/uv/getting-started/installation/
 Then continue with:
 ```
 **Recommended:**
-  - Commit the generated `.claude/CLAUDE.md` files so other developers get the same rules.
+  - **Optional:** If you want other contributors to benefit from the same rules, commit the generated `.claude/CLAUDE.md` files. Otherwise, add `.claude/` to `.gitignore` to keep them local.
   - `CLAUDE.local.md` has been created for personal/machine-specific rules (custom validation commands, local environment notes, personal workflow preferences). It is auto-loaded by Claude Code and gitignored.
 ```


### PR DESCRIPTION
## Summary
- Changed Step 8 summary from directive ('Commit the generated files') to suggestion ('Optional: commit if you want contributors to benefit, otherwise gitignore')
- Single line change in `plugins/pragma/skills/setup-project/SKILL.md`

## Test plan
- [ ] Run `/setup-project` and verify the summary uses suggestion wording

Fixes #77