### PR TITLE
Replace { } command grouping with subshells for zsh eval compat

### DIFF
--- a/plugins/pragma/skills/setup-project/SKILL.md
+++ b/plugins/pragma/skills/setup-project/SKILL.md
@@ -57,7 +57,7 @@ Check root directory AND immediate subdirectories for language markers.
 ```bash
 # Root level
 [[ -f go.mod ]] && echo "root:go"
-{ [[ -f pyproject.toml ]] || [[ -f setup.py ]]; } && echo "root:python"
+( [[ -f pyproject.toml ]] || [[ -f setup.py ]] ) && echo "root:python"
 [[ -f package.json ]] && echo "root:javascript"
 [[ -f tsconfig.json ]] && echo "root:typescript"
 [[ -f Cargo.toml ]] && echo "root:rust"
@@ -65,7 +65,7 @@ Check root directory AND immediate subdirectories for language markers.
 # Subdirectories (one level deep)
 for dir in */; do
   [[ -f "${dir}go.mod" ]] && echo "${dir%/}:go"
-  { [[ -f "${dir}pyproject.toml" ]] || [[ -f "${dir}setup.py" ]]; } && echo "${dir%/}:python"
+  ( [[ -f "${dir}pyproject.toml" ]] || [[ -f "${dir}setup.py" ]] ) && echo "${dir%/}:python"
   [[ -f "${dir}package.json" ]] && echo "${dir%/}:javascript"
   [[ -f "${dir}tsconfig.json" ]] && echo "${dir%/}:typescript"
   [[ -f "${dir}Cargo.toml" ]] && echo "${dir%/}:rust"
@@ -248,7 +248,7 @@ How would you like to manage API keys?
 
 **If user chooses "any-llm.ai platform":**
 ```bash
-uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then include in the summary:
@@ -265,7 +265,7 @@ Then include in the summary:
 
 **If user chooses "Direct provider keys":**
 ```bash
-uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then include in the summary:

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -70,7 +70,7 @@ How would you like to manage API keys?
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
 ```
 
 Then show:
@@ -88,7 +88,7 @@ Setup:
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated python "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --direct
 ```
 
 Then show:
@@ -195,7 +195,7 @@ Determine what code to review:
 ```bash
 # Get recently changed files (committed, then staged, then unstaged).
 # Filter out generated/vendor files.
-{ git diff HEAD~1 --name-only --diff-filter=ACMRT 2>/dev/null || git diff --cached --name-only --diff-filter=ACMRT 2>/dev/null || git diff --name-only --diff-filter=ACMRT; } | grep -v -E '(node_modules|vendor|\.min\.|\.generated\.|__pycache__|\.pyc$)'
+( git diff HEAD~1 --name-only --diff-filter=ACMRT 2>/dev/null || git diff --cached --name-only --diff-filter=ACMRT 2>/dev/null || git diff --name-only --diff-filter=ACMRT ) | grep -v -E '(node_modules|vendor|\.min\.|\.generated\.|__pycache__|\.pyc$)'
 ```
 
 Save the output as the file list for subsequent steps. Since each Bash tool invocation is isolated, you must re-derive or re-read file lists in each block that needs them (e.g., write to a temp file and read it back, or re-run the discovery command).


### PR DESCRIPTION
## Summary
- Replace `{ ... ; }` command grouping with `( ... )` subshells in PROTOCOL.md and setup-project SKILL.md to fix zsh eval failures (`(eval):1: command not found: }`)
- Remove unnecessary `python` prefix from `uv run` commands for `generate_config.py` in both files

## Changes
- **PROTOCOL.md line 198**: `{ git diff ... ; }` → `( git diff ... )`
- **PROTOCOL.md lines 73, 91**: Drop `python` from `uv run` generate_config.py commands
- **setup-project/SKILL.md lines 60, 68**: `{ [[ -f ... ]] || [[ -f ... ]]; }` → `( [[ -f ... ]] || [[ -f ... ]] )`
- **setup-project/SKILL.md lines 251, 268**: Drop `python` from `uv run` generate_config.py commands

## Test plan
- [ ] Run `/setup-project` in a zsh shell — verify no `command not found: }` errors
- [ ] Run `/star-chamber` — verify file discovery works without errors
- [ ] Verify `uv run` commands work without `python` prefix

Fixes #80