### PR TITLE
Bump plugin version to 3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",

--- a/plugins/pragma/skills/star-chamber/pyproject.toml
+++ b/plugins/pragma/skills/star-chamber/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "star-chamber"
-version = "2.0.0"
+version = "3.0.0"
 requires-python = ">=3.11"
 dependencies = [
     "any-llm-sdk>=1.8.6,<1.9.0",


### PR DESCRIPTION
## Summary
- Bump all version references from 2.0.0 to 3.0.0

## Breaking changes (since 2.0.0)
- **Rules migration (#93):** `/setup-project` now generates modular `.claude/rules/*.md` files instead of monolithic `.claude/CLAUDE.md`. Projects must re-run `/setup-project` to migrate. Legacy files are detected and cleaned up.
- **OpenCode compatibility (#93):** `/setup-project` now generates `opencode.json` with `instructions` glob so OpenCode auto-loads the same rules as Claude Code.
- **Legacy fallback removed (#93):** No backward compatibility with `.claude/CLAUDE.md` — this is a clean break.

## Other changes included in 3.0.0
- Clarify validator dispatch in implement Phase 3 (#84)
- Human-readable validation summaries (#85)
- Persist debate round results for context compaction (#86)
- Fix zsh eval errors for negated conditionals (#87)
- Pin star-chamber SDK versions (#88)
- Strengthen uncommitted changes handling (#89)
- Reframe commit guidance as suggestion (#90)
- Fix zsh eval brace grouping (#91)
- Add api_base support for local/self-hosted LLMs (#92)

## Files changed
- `.claude-plugin/marketplace.json` — 2.0.0 → 3.0.0
- `plugins/pragma/.claude-plugin/plugin.json` — 2.0.0 → 3.0.0
- `plugins/pragma/skills/star-chamber/pyproject.toml` — 2.0.0 → 3.0.0

## Test plan
- [ ] Verify `/setup-project` runs correctly on a fresh project
- [ ] Verify plugin version shows 3.0.0 in Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Pragma plugin version upgraded to 3.0.0
  * Plugin metadata upgraded to 3.0.0
  * Associated component versions upgraded to 3.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->