### PR TITLE
Use fixed parent temp dir for star-chamber debate mode

### DIFF
--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -377,12 +377,12 @@ Context compaction can fire between rounds and destroy previous round responses.
 
 Before the first round, create the fixed parent directory and a unique run subdirectory, then inform the user:
 ```bash
-mkdir -p "${TMPDIR:-/tmp}/star-chamber" && SC_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/star-chamber/run-XXXXXX")
+SC_PARENT="${TMPDIR:-/tmp}/star-chamber"; mkdir -p "$SC_PARENT" && chmod 700 "$SC_PARENT" && SC_TMPDIR=$(mktemp -d "$SC_PARENT/run-XXXXXX")
 ```
 
-Tell the user: _"Debate mode will read and write round results in `${TMPDIR:-/tmp}/star-chamber/`. Approve access to this directory to avoid repeated prompts."_
+Tell the user: _"Debate mode will read and write round results in `<resolved SC_PARENT path>`. Approve access to this directory to avoid repeated prompts."_ Use the resolved value of `$SC_PARENT` (e.g. `/tmp/star-chamber`) so the path the user sees matches the actual permission prompt.
 
-The fixed parent path lets the user grant blanket Bash permission once, while the unique `run-XXXXXX` subdirectory keeps concurrent star-chamber sessions isolated from each other.
+The fixed parent path lets the user grant blanket Bash permission once, while the unique `run-XXXXXX` subdirectory keeps concurrent star-chamber sessions isolated from each other. The `chmod 700` ensures only the current user can access the directory.
 
 For each round, redirect `llm_council.py` stdout directly to a round file instead of capturing in a shell variable:
 ```bash


### PR DESCRIPTION
## Summary

- Replace random `mktemp -d` path with a fixed `/tmp/star-chamber` parent directory and unique `run-XXXXXX` subdirectories per session
- Users can grant Bash permission once for the fixed parent path, avoiding repeated prompts for each read/write during debate rounds
- Per-run subdirectories keep concurrent star-chamber sessions isolated from each other

## Test plan

- [ ] Run `/star-chamber --debate --rounds 2` on a project with changes
- [ ] Confirm the first Bash permission prompt mentions `/tmp/star-chamber/`
- [ ] After granting permission, subsequent read/write operations should not prompt again
- [ ] Verify the run subdirectory is cleaned up after completion
- [ ] Run two concurrent star-chamber sessions and verify they don't interfere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user notifications clarifying debate mode access requirements to reduce prompts.

* **Bug Fixes**
  * Improved handling of round results to ensure access to previous provider responses during debate sessions.
  * Enhanced temporary directory management with automatic cleanup after debate completion.

* **Documentation**
  * Updated protocol documentation with clarifications on file access and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->