### PR TITLE
Bump plugin version to 3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",

--- a/plugins/pragma/skills/star-chamber/pyproject.toml
+++ b/plugins/pragma/skills/star-chamber/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "star-chamber"
-version = "3.0.1"
+version = "3.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "any-llm-sdk>=1.8.6,<1.9.0",


### PR DESCRIPTION
## Summary

- Bump version from 3.0.1 to 3.1.0 across all three locations

## Changes since 3.0.1

- #97 — Add `local` provider flag with graceful key resolution (minor feature)
- #98 — Prevent API key leaks in star-chamber protocol instructions
- #99 — Fix protocol gaps for prompt construction and variable persistence
- #65 — Document marketplace auto-update and manual update steps in README

## Test plan

- [ ] Verify version is 3.1.0 in `plugins/pragma/.claude-plugin/plugin.json`
- [ ] Verify version is 3.1.0 in `.claude-plugin/marketplace.json`
- [ ] Verify version is 3.1.0 in `plugins/pragma/skills/star-chamber/pyproject.toml`
- [ ] Tag `3.1.0` after merge