### PR TITLE
Fix platform client connecting to localhost instead of production API

### DIFF
--- a/plugins/pragma/skills/star-chamber/llm_council.py
+++ b/plugins/pragma/skills/star-chamber/llm_council.py
@@ -346,8 +346,8 @@ async def _resolve_platform_keys(
     )
 
     # Match the env var and default used by any-llm-sdk's platform provider.
-    platform_base = os.environ.get("ANY_LLM_PLATFORM_URL", "https://platform-api.any-llm.ai")
-    platform_url = f"{platform_base}/api/v1"
+    platform_base = os.environ.get("ANY_LLM_PLATFORM_URL", "https://platform-api.any-llm.ai").rstrip("/")
+    platform_url = platform_base if platform_base.endswith("/api/v1") else f"{platform_base}/api/v1"
     client = AnyLLMPlatformClient(any_llm_platform_url=platform_url)
     resolved = []
     for p in providers:


### PR DESCRIPTION
## Summary

- Pass production platform URL to `AnyLLMPlatformClient` constructor instead of letting it default to `localhost:8000`
- Read `ANY_LLM_PLATFORM_URL` env var (same as the SDK) with default `https://platform-api.any-llm.ai`
- Add 2 tests: default production URL and env var override

## Root cause

Regression from #97. The refactored `_resolve_platform_keys()` instantiates `AnyLLMPlatformClient()` with no arguments. The client library defaults to `http://localhost:8000/api/v1`, but the any-llm-sdk's own platform provider reads `ANY_LLM_PLATFORM_URL` and defaults to `https://platform-api.any-llm.ai`. The old code (pre-#97) just cleared api_key fields and let the SDK handle routing — the explicit client bypassed that.

## Test plan

- [x] All 24 tests pass (including 2 new URL tests)
- [ ] Run star-chamber with platform mode to verify production connectivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable platform endpoint configuration with production defaults.

* **Tests**
  * Added test coverage for platform URL configuration scenarios, including production and custom endpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->