### PR TITLE
Bump plugin version to 3.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",

--- a/plugins/pragma/skills/star-chamber/pyproject.toml
+++ b/plugins/pragma/skills/star-chamber/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "star-chamber"
-version = "3.1.0"
+version = "3.1.1"
 requires-python = ">=3.11"
 dependencies = [
     "any-llm-sdk>=1.8.6,<1.9.0",


### PR DESCRIPTION
## Summary

- Bump version from 3.1.0 to 3.1.1 across all three locations

## Changes since 3.1.0

- #101 — Fix platform client connecting to localhost instead of production API

## Merge order

Merge #101 first, then this PR.

## Test plan

- [ ] Verify version is 3.1.1 in all three files
- [ ] Tag `3.1.1` after merge