### PR TITLE
Bump plugin version to 3.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",

--- a/plugins/pragma/skills/star-chamber/pyproject.toml
+++ b/plugins/pragma/skills/star-chamber/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "star-chamber"
-version = "3.1.1"
+version = "3.1.2"
 requires-python = ">=3.11"
 dependencies = [
     "any-llm-sdk>=1.8.6,<1.9.0",


### PR DESCRIPTION
## Summary

- Bumps version from 3.1.1 to 3.1.2 in `plugin.json`, `pyproject.toml`, and `marketplace.json`

## Test plan

- [x] Version strings updated in all 3 files
- [x] No other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 3.1.2 with routine maintenance updates across plugin and project configuration files. No new features or breaking changes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->