### PR TITLE
Fix path-scoped rule matching for root-level files

### DIFF
--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -266,10 +266,17 @@ if [[ -d "$RULE_DIR" ]]; then
       pattern="${pattern#- }"
       pattern="${pattern%\"}"
       pattern="${pattern#\"}"
+      # When pattern starts with **/, also try without the prefix.
+      # Bash [[ == ]] treats **/ as requiring a path separator,
+      # so **/*.py won't match root-level files like main.py.
+      alt_pattern=""
+      if [[ "$pattern" == \*\*/* ]]; then
+        alt_pattern="${pattern#\*\*/}"
+      fi
       while IFS= read -r file_path; do
         [[ -z "$file_path" ]] && continue
         # shellcheck disable=SC2254
-        if [[ "$file_path" == $pattern ]]; then
+        if [[ "$file_path" == $pattern ]] || [[ -n "$alt_pattern" && "$file_path" == $alt_pattern ]]; then
           matched=true
           break
         fi


### PR DESCRIPTION
## Summary

- Star-chamber's path-scoped rule matching uses `[[ "$file_path" == $pattern ]]` which fails for root-level files when the pattern starts with `**/`
- `**/*.py` matches `pkg/mod.py` but not `main.py` because bash's `[[ == ]]` treats `**/` as requiring a path separator
- When the pattern starts with `**/`, now also tries matching with the prefix stripped

## Test plan

- [ ] Create a rule file with `paths: **/*.py` and verify it matches both `main.py` (root) and `pkg/mod.py` (nested)
- [ ] Verify patterns without `**/` prefix are unaffected

Fixes #106

Found by CodeRabbit review on #105 ([comment](https://github.com/peteski22/agent-pragma/pull/105#discussion_r2874523011)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed file pattern matching to correctly resolve root-level files against wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->