### PR TITLE
Fix stale uv run reference in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -603,7 +603,7 @@ The skill has `model-invocable: false` — it only fires on explicit user reques
 
 **Key characteristics:**
 - Advisory only (doesn't block like validators)
-- Uses `any-llm-sdk` via `uv run` (no global Python install needed)
+- Uses `any-llm-sdk` via `uvx` (no global Python install needed)
 - Supports parallel and debate review modes, plus design questions
 - Persistent project memory for learning codebase patterns across reviews (agent only)
 


### PR DESCRIPTION
## Summary

- Update star-chamber invocation reference from `uv run` to `uvx` in the Advisory Skills section of ARCHITECTURE.md, reflecting the SDK migration

## Test plan

- [x] Verified no other stale references to `llm_council.py`, `spec/council-protocol/`, or `uv run` in README.md or ARCHITECTURE.md