### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",


### PR DESCRIPTION
## Summary
- Bumps plugin version from 3.1.2 → 3.2.0 in marketplace.json and plugin.json

### Changes since 3.1.2
- **New**: error-handling cross-language validator (#108)
- **New**: council protocol specification and JSON schemas (#110)
- **Rewrite**: star-chamber skill to consume PyPI SDK (#111)
- **Enhancement**: all skills work without `/setup-project` (#105)
- **Fix**: path-scoped rule matching for root-level files (#109)
- **Docs**: restructured docs (#107), fixed stale reference (#112)

## Test plan
- [ ] Verify marketplace.json version is 3.2.0
- [ ] Verify plugin.json version is 3.2.0
- [ ] Install plugin and confirm version reported correctly