### PR TITLE
Fix star-chamber protocol permission prompts

### DIFF
--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -309,7 +309,7 @@ SC_TMPDIR="<literal path from mktemp output>"; rm -rf "$SC_TMPDIR"
 
 ## Step 4: Present Results to User
 
-Parse the JSON output from Step 3 and present using the appropriate format below. In **non-debate mode**, the JSON is returned directly by the Bash tool response — parse it in-context. In **debate mode**, use the **Read tool** with the literal temp file path to read the final round's JSON (e.g., reading `/tmp/star-chamber/run-KdkPeA/round-2.json`). Do NOT use `python3 -c`, `cat`, or other shell commands to read result files. Do NOT include raw JSON in the terminal summary — the markdown formats below are for human consumption.
+Parse the JSON output from Step 3 and present using the appropriate format below. In **non-debate mode**, the JSON is returned directly by the Bash tool response — parse it in-context. In **debate mode**, use the **Read tool** with the literal temp file path to read the final round's JSON (e.g., reading `/tmp/star-chamber/run-KdkPeA/round-2.json`). Do NOT use `python3 -c`, `cat`, or other shell commands to read result files. Do NOT include raw JSON in the terminal summary — the Markdown formats below are for human consumption.
 
 ### Code Review Format
 


### PR DESCRIPTION
## Summary
- Restructure cross-invocation file access rules as bullet list (read vs write vs single-invocation)
- Split Step 1 pipeline into two commands, fixing the protocol's own runtime constraint violation
- Add `|| true` to grep for empty-input exit code handling
- Add explicit non-debate stdout invariant in Step 3
- Scope Read tool instruction in Step 4 to debate mode only
- Use Bash heredoc for synthesis writing (Write tool triggers permission prompts)
- Restore `--format json` in debate flow diagram
- Clarify `;` vs `&&` scope to single-line invocations

Informed by 2-round star-chamber debate review (openai + anthropic + gemini).

## Test plan
- [ ] Run `/star-chamber --debate --rounds 2` and verify no permission prompts for file I/O
- [ ] Run `/star-chamber` (non-debate) and verify stdout parsing works
- [ ] Verify Step 1 handles empty git diff without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated protocol guidance for file access rules, single-line vs multi-line invocation behaviour, and clearer read/write semantics across operations.
  * Clarified output handling for different modes and when results are consumed or fetched.
  * Revised file-list generation and explicit filtering steps to improve reliability.
  * Added examples and explicit guidance for temporary directory handling, synthesis output writing, and intermediate result workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->