### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",


### PR DESCRIPTION
## Summary
- Bumps plugin version from 3.2.0 → 3.2.1 in marketplace.json and plugin.json

### Changes since 3.2.0
- **Fix**: Star-chamber protocol permission prompts and internal inconsistencies (#114)

## Test plan
- [ ] Verify marketplace.json version is 3.2.1
- [ ] Verify plugin.json version is 3.2.1