### PR TITLE
Migrate star-chamber integration to 0.2.0 Otari gateway

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -605,7 +605,7 @@ The skill has `model-invocable: false` — it only fires on explicit user reques
 
 **Key characteristics:**
 - Advisory only (doesn't block like validators)
-- Uses `any-llm-sdk` via `uvx` (no global Python install needed)
+- Uses `star-chamber` (built on `any-llm-sdk`) via `uvx` (no global Python install needed); providers run with direct keys or routed through an Otari gateway
 - Supports parallel and debate review modes, plus design questions
 - Persistent project memory for learning codebase patterns across reviews (agent only)
 

--- a/README.md
+++ b/README.md
@@ -217,10 +217,11 @@ flowchart TD
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `STAR_CHAMBER_CONFIG` | No | Custom path to star-chamber config (default: `~/.config/star-chamber/providers.json`) |
-| `ANY_LLM_KEY` | For `/star-chamber` | Platform key from [any-llm.ai](https://any-llm.ai) |
-| `OPENAI_API_KEY` | For `/star-chamber` | OpenAI API key (if not using any-llm.ai) |
-| `ANTHROPIC_API_KEY` | For `/star-chamber` | Anthropic API key (if not using any-llm.ai) |
-| `GEMINI_API_KEY` | For `/star-chamber` | Google Gemini API key (if not using any-llm.ai) |
+| `OTARI_API_BASE` | For `/star-chamber` (Otari mode) | Base URL of your [Otari](https://github.com/mozilla-ai/otari) gateway |
+| `OTARI_API_KEY` | For `/star-chamber` (Otari mode) | Otari gateway API key (or set `OTARI_PLATFORM_TOKEN` for a hosted platform) |
+| `OPENAI_API_KEY` | For `/star-chamber` (direct mode) | OpenAI API key (if not routing through Otari) |
+| `ANTHROPIC_API_KEY` | For `/star-chamber` (direct mode) | Anthropic API key (if not routing through Otari) |
+| `GEMINI_API_KEY` | For `/star-chamber` (direct mode) | Google Gemini API key (if not routing through Otari) |
 
 ## Updating
 

--- a/plugins/pragma/reference/star-chamber/generate_config.py
+++ b/plugins/pragma/reference/star-chamber/generate_config.py
@@ -5,11 +5,13 @@ Two modes derive from a single direct-keys reference (providers.json):
 - ``--direct``  Per-provider API keys via ``${ENV_VAR}`` references (the
                 reference as-is). Non-OpenAI providers need their SDK at run
                 time (``uvx --with anthropic --with google-genai ...``).
-- ``--otari``   Route every provider through an Otari gateway: strip per-provider
-                keys, add a top-level ``otari`` block resolved from
-                ``OTARI_API_BASE``/``OTARI_API_KEY``, and prefix each model with
-                its provider label (``openai:gpt-4o``) per Otari's naming
-                convention.
+- ``--otari``   Route non-local providers through an Otari gateway: strip their
+                keys and prefix each model with its provider label
+                (``openai:gpt-4o``) per Otari's naming convention, then add a
+                top-level ``otari`` block. ``local: true`` providers bypass the
+                gateway and are left untouched. The block templates only
+                ``api_base``; ``api_key`` is omitted so the Otari client resolves
+                ``OTARI_API_KEY`` or falls back to ``OTARI_PLATFORM_TOKEN``.
 
 NOTE: the ``provider:model`` prefix follows Otari's documented convention; verify
 it against your gateway's docs if a provider rejects the model name.
@@ -40,17 +42,25 @@ def main() -> None:
         sys.exit(1)
 
     if args.otari:
-        ref["providers"] = [
-            {
-                **{k: v for k, v in p.items() if k != "api_key"},
-                "model": f"{p['provider']}:{p['model']}",
-            }
-            for p in ref["providers"]
-        ]
-        # Resolved from OTARI_API_BASE/OTARI_API_KEY at runtime; omit either to
-        # fall back to the environment, or set OTARI_PLATFORM_TOKEN for a hosted
-        # platform that uses Bearer-token auth.
-        ref["otari"] = {"api_base": "${OTARI_API_BASE}", "api_key": "${OTARI_API_KEY}"}
+        # Local providers bypass Otari (own route/key/model), so rewrite only
+        # the providers that route through the gateway and leave the rest as-is.
+        rewritten = []
+        for p in ref["providers"]:
+            if p.get("local", False):
+                rewritten.append(p)
+                continue
+            rewritten.append(
+                {
+                    **{k: v for k, v in p.items() if k != "api_key"},
+                    "model": f"{p['provider']}:{p['model']}",
+                }
+            )
+        ref["providers"] = rewritten
+        # Template only api_base; omit api_key so the Otari client resolves
+        # OTARI_API_KEY at runtime, or falls back to OTARI_PLATFORM_TOKEN for a
+        # hosted platform. A literal "${OTARI_API_KEY}" would expand to "" when
+        # unset and suppress that fallback.
+        ref["otari"] = {"api_base": "${OTARI_API_BASE}"}
 
     dest = pathlib.Path.home() / ".config" / "star-chamber" / "providers.json"
     try:

--- a/plugins/pragma/reference/star-chamber/generate_config.py
+++ b/plugins/pragma/reference/star-chamber/generate_config.py
@@ -1,4 +1,19 @@
-"""Generate star-chamber provider config from reference file."""
+"""Generate star-chamber provider config from reference file.
+
+Two modes derive from a single direct-keys reference (providers.json):
+
+- ``--direct``  Per-provider API keys via ``${ENV_VAR}`` references (the
+                reference as-is). Non-OpenAI providers need their SDK at run
+                time (``uvx --with anthropic --with google-genai ...``).
+- ``--otari``   Route every provider through an Otari gateway: strip per-provider
+                keys, add a top-level ``otari`` block resolved from
+                ``OTARI_API_BASE``/``OTARI_API_KEY``, and prefix each model with
+                its provider label (``openai:gpt-4o``) per Otari's naming
+                convention.
+
+NOTE: the ``provider:model`` prefix follows Otari's documented convention; verify
+it against your gateway's docs if a provider rejects the model name.
+"""
 
 import argparse
 import json
@@ -9,8 +24,8 @@ import sys
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate star-chamber config.")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--platform", action="store_true", help="Platform mode (strips api_key fields).")
-    group.add_argument("--direct", action="store_true", help="Direct keys mode (strips platform field).")
+    group.add_argument("--otari", action="store_true", help="Otari gateway mode (routes all providers through Otari).")
+    group.add_argument("--direct", action="store_true", help="Direct keys mode (per-provider API keys).")
     args = parser.parse_args()
 
     ref_path = pathlib.Path(__file__).parent / "providers.json"
@@ -24,12 +39,18 @@ def main() -> None:
         print(f"Invalid JSON in reference file {ref_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if args.platform:
+    if args.otari:
         ref["providers"] = [
-            {k: v for k, v in p.items() if k != "api_key"} for p in ref["providers"]
+            {
+                **{k: v for k, v in p.items() if k != "api_key"},
+                "model": f"{p['provider']}:{p['model']}",
+            }
+            for p in ref["providers"]
         ]
-    else:
-        ref.pop("platform", None)
+        # Resolved from OTARI_API_BASE/OTARI_API_KEY at runtime; omit either to
+        # fall back to the environment, or set OTARI_PLATFORM_TOKEN for a hosted
+        # platform that uses Bearer-token auth.
+        ref["otari"] = {"api_base": "${OTARI_API_BASE}", "api_key": "${OTARI_API_KEY}"}
 
     dest = pathlib.Path.home() / ".config" / "star-chamber" / "providers.json"
     try:

--- a/plugins/pragma/reference/star-chamber/providers.json
+++ b/plugins/pragma/reference/star-chamber/providers.json
@@ -1,5 +1,4 @@
 {
-  "platform": "any-llm",
   "providers": [
     {
       "provider": "openai",

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -87,12 +87,12 @@ See: https://docs.astral.sh/uv/getting-started/installation/
 
 **If config is missing**, ask how to manage API keys:
 
-```
+```text
 Star-Chamber requires provider configuration.
 
 How would you like to manage API keys?
 
-[Otari gateway] - Route all providers through an Otari gateway with a single OTARI_API_KEY
+[Otari gateway] - Route all providers through an Otari gateway (OTARI_API_KEY, or OTARI_PLATFORM_TOKEN for a hosted platform)
 [Direct provider keys] - Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY individually
 [Skip] - I'll set it up manually later
 ```
@@ -105,7 +105,7 @@ PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_
 ```
 
 Then show:
-```
+```text
 Created ~/.config/star-chamber/providers.json (Otari gateway mode)
 
 Setup:
@@ -128,7 +128,7 @@ PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_
 ```
 
 Then show:
-```
+```text
 Created ~/.config/star-chamber/providers.json (direct keys mode)
 
 Set these environment variables:
@@ -141,7 +141,7 @@ Edit the config to remove providers you don't have keys for.
 
 **If user chooses "Skip":**
 
-```
+```text
 To set up manually later, see the Configuration section below or run /star-chamber again.
 ```
 
@@ -595,7 +595,7 @@ Instead of setting individual provider API keys, you can route every non-local p
        {"provider": "openai", "model": "openai:gpt-4o"},
        {"provider": "anthropic", "model": "anthropic:claude-sonnet-4-20250514"}
      ],
-     "otari": {"api_base": "${OTARI_API_BASE}", "api_key": "${OTARI_API_KEY}"}
+     "otari": {"api_base": "${OTARI_API_BASE}"}
    }
    ```
 3. Point at the gateway and authenticate:
@@ -634,7 +634,7 @@ Otari expects the `model` field in `provider:model` form; consult Otari's docume
 ```
 - Verify the environment variable is set: `[ -n "$OPENAI_API_KEY" ] && echo "set" || echo "not set"`
 - Check if the key is valid (not expired or revoked).
-- For Otari mode, verify `OTARI_API_KEY` (or `OTARI_PLATFORM_TOKEN`) is set: `[ -n "$OTARI_API_KEY" ] && echo "set" || echo "not set"`
+- For Otari mode, verify `OTARI_API_KEY` (or `OTARI_PLATFORM_TOKEN`) is set: `{ [ -n "$OTARI_API_KEY" ] || [ -n "$OTARI_PLATFORM_TOKEN" ]; } && echo "set" || echo "not set"`
 
 **Request timed out:**
 ```json

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -46,13 +46,15 @@ uvx star-chamber <command> [options] [arguments]
 
 `uvx` installs `star-chamber` from PyPI (cached after first run) and executes in isolation — no interference with the host project's environment.
 
-**Platform mode requires the `[platform]` extra.** When using platform mode (`"platform": "any-llm"` in config), install star-chamber with the platform extra. Provider SDKs beyond OpenAI still need `--with` flags:
+**Version:** This protocol targets star-chamber **0.2.x**, whose config routes gateway traffic through a top-level `otari` object. A pre-0.2 `"platform": "any-llm"` config is rejected by the loader; regenerate it (see Step 0) if you hit that error.
+
+**Provider SDKs are not all included by default.** Only the OpenAI SDK is a base dependency of `any-llm-sdk`. In **direct** mode, each non-OpenAI provider (Anthropic, Gemini, Cohere, etc.) needs its SDK added via `--with` flags:
 
 ```bash
-uvx --from 'star-chamber[platform]' --with anthropic --with google-genai star-chamber <command> [options] [arguments]
+uvx --with anthropic --with google-genai star-chamber <command> [options] [arguments]
 ```
 
-**Provider SDKs are not all included by default.** Only the OpenAI SDK is a base dependency of `any-llm-sdk`. Other providers (Anthropic, Gemini, Cohere, etc.) are optional extras. Add `--with` flags for each non-OpenAI provider you use.
+In **Otari** mode every non-local provider is dispatched through the OpenAI-compatible Otari gateway, so no per-provider `--with` flags are required — plain `uvx star-chamber` is enough.
 
 ## Step 0: Check Prerequisites
 
@@ -90,27 +92,32 @@ Star-Chamber requires provider configuration.
 
 How would you like to manage API keys?
 
-[any-llm.ai platform] - Single ANY_LLM_KEY, centralized key vault, usage tracking
+[Otari gateway] - Route all providers through an Otari gateway with a single OTARI_API_KEY
 [Direct provider keys] - Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY individually
 [Skip] - I'll set it up manually later
 ```
 
-**If user chooses "any-llm.ai platform":**
+**If user chooses "Otari gateway":**
 
 ```bash
 STAR_CHAMBER_PATH="<set by caller>"
-PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --platform
+PLUGIN_ROOT="$STAR_CHAMBER_PATH/../.."; uv run --no-project --isolated "$PLUGIN_ROOT/reference/star-chamber/generate_config.py" --otari
 ```
 
 Then show:
 ```
-Created ~/.config/star-chamber/providers.json (platform mode)
+Created ~/.config/star-chamber/providers.json (Otari gateway mode)
 
 Setup:
-  1. Create account at https://any-llm.ai
-  2. Create a project and add your provider API keys
-  3. Copy your project key and set:
-     export ANY_LLM_KEY="ANY.v1...."
+  1. Point at your Otari gateway:
+     export OTARI_API_BASE="https://your-gateway.example/v1"
+  2. Authenticate:
+     export OTARI_API_KEY="..."
+     # For a hosted Otari platform with Bearer-token auth, omit OTARI_API_KEY
+     # and set OTARI_PLATFORM_TOKEN instead.
+
+The generated config prefixes each model as provider:model (Otari's naming
+convention). Verify the prefixes against your gateway's docs.
 ```
 
 **If user chooses "Direct provider keys":**
@@ -510,7 +517,7 @@ SC_TMPDIR="<literal path>"; rm -rf "$SC_TMPDIR"
 
 Provider configuration is read from `~/.config/star-chamber/providers.json`. Override with `STAR_CHAMBER_CONFIG` environment variable.
 
-The reference configuration with current models is maintained at `reference/star-chamber/providers.json` in the pragma plugin. Update models there and re-run `generate_config.py` with `--platform` or `--direct` to propagate changes to your local config.
+The reference configuration with current models is maintained at `reference/star-chamber/providers.json` in the pragma plugin. Update models there and re-run `generate_config.py` with `--otari` or `--direct` to propagate changes to your local config.
 
 ### Schemas
 
@@ -531,10 +538,10 @@ uvx star-chamber schema code-review-result
 |-------|----------|-------------|
 | `provider` | yes | Provider name (e.g., `openai`, `anthropic`, `llamafile`, `ollama`). |
 | `model` | yes | Model identifier. |
-| `api_key` | no | API key or `${ENV_VAR}` reference. Omit for platform mode or keyless local providers. |
+| `api_key` | no | API key or `${ENV_VAR}` reference. Omit for Otari mode or keyless local providers. |
 | `max_tokens` | no | Max response tokens (default: 16384). |
 | `api_base` | no | Custom base URL for local/self-hosted LLMs. Omit for cloud providers — the SDK uses built-in defaults. |
-| `local` | no | Set to `true` for local/self-hosted providers (default: `false`). See [Platform mode and local providers](#platform-mode-and-local-providers). |
+| `local` | no | Set to `true` for local/self-hosted providers (default: `false`). See [Otari mode and local providers](#otari-mode-and-local-providers). |
 
 ### Local/self-hosted LLM examples
 
@@ -560,47 +567,46 @@ uvx star-chamber schema code-review-result
 
 Cloud-hosted providers do not need `api_base` or `local` — omit both fields.
 
-### Platform mode and local providers
+### Otari mode and local providers
 
-When `platform: "any-llm"` is configured, the council fetches API keys from the any-llm platform for each provider. Providers marked `local: true` get special treatment:
+When a top-level `otari` object is configured, every **non-local** provider is dispatched through the Otari gateway: the call uses `provider="otari"` with Otari's shared `api_base`/`api_key`, and the per-provider `provider` field becomes a label. The `model` must use Otari's `provider:model` naming (e.g. `openai:gpt-4o`).
 
-- **Key fetch tolerant:** If the platform has no key for a local provider, the council proceeds with an empty key instead of failing.
-- **Network fault tolerant:** If the platform is unreachable, local providers still proceed. Non-local providers fail fast.
-- **Auth error guidance:** If a local provider returns an auth error, the error message suggests adding the key to the any-llm platform or setting `api_key` directly in `providers.json`.
+Providers marked `local: true` are treated differently:
 
-Local providers can still use keys: if the platform has a key stored for a local provider, it will be fetched and used normally. The `local` flag only affects the *failure* path.
+- **Always bypass Otari.** Local providers ignore the gateway and call their own `api_base` with their own `provider` and `api_key`, even when `otari` is set.
+- **Intended for self-hosted models** (Ollama, llamafile, etc.) that should not be routed through the gateway.
 
-## Using any-llm.ai Managed Platform (Optional)
+Auth failures are reported per route: gateway calls report that authentication failed at the Otari gateway, while local calls name the provider and point at its key.
 
-Instead of setting individual API keys, you can use the [any-llm.ai](https://any-llm.ai) managed platform for:
-- **Centralized key management** — Store provider keys securely (encrypted client-side).
-- **Usage tracking** — Automatic cost and token tracking across all providers.
-- **Single authentication** — One `ANY_LLM_KEY` instead of multiple provider keys.
+## Using an Otari Gateway (Optional)
 
-### Platform Setup
+Instead of setting individual provider API keys, you can route every non-local provider through [Otari](https://github.com/mozilla-ai/otari), Mozilla AI's OpenAI-compatible LLM gateway:
+- **Centralized key management** — Provider keys live at the gateway, not on each developer's machine.
+- **Single authentication** — One `OTARI_API_KEY` (or a hosted-platform Bearer token) instead of per-provider keys.
+- **Uniform routing** — Otari selects the upstream provider; star-chamber only needs the OpenAI-compatible client.
 
-1. Create account at https://any-llm.ai
-2. Create a project and add your provider API keys (OpenAI, Anthropic, Gemini, etc.)
-3. Copy your project key
-4. Set environment variable:
-   ```bash
-   export ANY_LLM_KEY="ANY.v1.abc123..."
-   ```
-5. Enable platform mode in your config (`~/.config/star-chamber/providers.json`):
+### Otari Setup
+
+1. Stand up or obtain access to an Otari gateway (see Otari's documentation).
+2. Generate an Otari-mode config (`~/.config/star-chamber/providers.json`) via Step 0, or add a top-level `otari` block by hand:
    ```json
    {
-     "platform": "any-llm",
-     ...
+     "providers": [
+       {"provider": "openai", "model": "openai:gpt-4o"},
+       {"provider": "anthropic", "model": "anthropic:claude-sonnet-4-20250514"}
+     ],
+     "otari": {"api_base": "${OTARI_API_BASE}", "api_key": "${OTARI_API_KEY}"}
    }
    ```
+3. Point at the gateway and authenticate:
+   ```bash
+   export OTARI_API_BASE="https://your-gateway.example/v1"
+   export OTARI_API_KEY="..."
+   ```
 
-### What Gets Tracked
+`api_base`/`api_key` may be omitted from the config to resolve from the `OTARI_API_BASE`/`OTARI_API_KEY` environment variables. For a hosted Otari platform that uses Bearer-token auth, omit `OTARI_API_KEY` and set `OTARI_PLATFORM_TOKEN` instead — the Otari client detects it and switches to platform mode automatically.
 
-The platform tracks **metadata only** (never prompts/responses):
-- Provider and model used.
-- Token counts (input/output).
-- Request timestamps.
-- Cost estimates.
+Otari expects the `model` field in `provider:model` form; consult Otari's documentation for its exact naming convention. Providers marked `local: true` always bypass the gateway.
 
 ## Security Considerations
 
@@ -608,7 +614,7 @@ The platform tracks **metadata only** (never prompts/responses):
 - **Prefer environment variables** over hardcoding keys in the config file.
 - Use `${ENV_VAR}` syntax in config to reference environment variables.
 - Never commit `providers.json` with actual API keys to version control.
-- The any-llm.ai platform mode is recommended for team environments.
+- Otari gateway mode is recommended for team environments — provider keys stay at the gateway rather than on developer machines.
 
 **Key Handling:**
 - **Never echo, log, or print API key values** in shell commands or debug output.
@@ -616,7 +622,7 @@ The platform tracks **metadata only** (never prompts/responses):
 - Avoid shell expansions (`${VAR:-...}`, `${VAR:+...}`) on key variables in echo/print statements — these can leak values.
 
 **Error Output:**
-- API keys are automatically redacted from error messages (patterns: `sk-*`, `ANY.v1.*`, etc.).
+- API keys are automatically redacted from error messages (patterns: `Bearer ...`, `sk-*`, `key-*`, `api_key=...`, etc.).
 
 ## Troubleshooting
 
@@ -628,7 +634,7 @@ The platform tracks **metadata only** (never prompts/responses):
 ```
 - Verify the environment variable is set: `[ -n "$OPENAI_API_KEY" ] && echo "set" || echo "not set"`
 - Check if the key is valid (not expired or revoked).
-- For platform mode, verify `ANY_LLM_KEY` is set: `[ -n "$ANY_LLM_KEY" ] && echo "set" || echo "not set"`
+- For Otari mode, verify `OTARI_API_KEY` (or `OTARI_PLATFORM_TOKEN`) is set: `[ -n "$OTARI_API_KEY" ] && echo "set" || echo "not set"`
 
 **Request timed out:**
 ```json
@@ -654,7 +660,7 @@ When some providers succeed and others fail, the JSON output includes `failed_pr
 uvx star-chamber list-providers
 ```
 
-This shows all configured providers, their models, and connection status (direct, platform, or local).
+This shows all configured providers, their models, and connection status (direct, otari, or local).
 
 ## Cost Warning
 


### PR DESCRIPTION
## What

star-chamber 0.2.0 removed the `platform: "any-llm"` config mode and now
rejects it at load time, replacing it with a top-level `otari` object that
routes non-local providers through an OpenAI-compatible gateway. Since the
plugin calls a bare (unpinned) `uvx star-chamber`, the previous config and
docs break on the 0.2.0 release.

## Changes

- **`reference/star-chamber/providers.json`** — drop the rejected `platform`
  key; the reference is now a clean direct-keys canonical.
- **`reference/star-chamber/generate_config.py`** — `--platform` → `--otari`:
  emits the `otari` block, applies Otari's `provider:model` naming, and strips
  per-provider keys. `--direct` is unchanged.
- **`PROTOCOL.md`** — remove the `[platform]` uvx extra (Otari routes through
  the OpenAI-compatible client, so no per-provider `--with` extras); rework the
  Step 0 setup flow to Otari + `OTARI_*` env vars; rewrite the platform and
  managed-platform sections; fix troubleshooting and `list-providers` status.
- **`README.md` / `ARCHITECTURE.md`** — `OTARI_API_BASE`/`OTARI_API_KEY` env
  vars and a routing note.

## Verification

Generated both modes into a throwaway HOME and loaded them through the local
0.2.0 SDK: `list-providers` reports `[direct]` and `[otari]` respectively, and
a legacy `platform` config is confirmed rejected with the migration error.

## Note

The matching `4.0.0` version bump is a separate PR and should merge after this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Star‑Chamber docs to v0.2.x with Otari gateway routing and revised setup guidance.
  * Environment variables updated: OTARI_API_BASE / OTARI_API_KEY introduced; generic ANY_LLM_KEY removed; direct provider keys remain documented.
  * Protocol and troubleshooting text updated to reflect direct, otari and local connection modes.

* **Configuration**
  * Config generation supports --direct and --otari modes; Otari mode rewrites provider entries and adds an otari block with api_base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->