### PR TITLE
Bump pragma to 4.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pragma",
       "source": "./plugins/pragma",
       "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
-      "version": "3.2.3",
+      "version": "4.0.0",
       "category": "development",
       "tags": ["validation", "code-quality", "go", "python", "typescript", "security", "linting", "llm-council"]
     }

--- a/plugins/pragma/.claude-plugin/plugin.json
+++ b/plugins/pragma/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pragma",
-  "version": "3.2.3",
+  "version": "4.0.0",
   "description": "Deterministic linting hooks, semantic code validators, and a multi-LLM advisory council. Enforces coding rules mechanically — not by suggestion.",
   "author": { "name": "Peter Wilson" },
   "repository": "https://github.com/peteski22/agent-pragma",


### PR DESCRIPTION
Bumps `pragma` 3.2.3 → 4.0.0 in `marketplace.json` and `plugin.json`.

Major bump because the star-chamber → Otari migration changes the provider
config format (`platform` removed and rejected by the SDK), which breaks
existing `providers.json` files.

**Merge after** the migration PR so `main` doesn't advertise 4.0.0 before the
breaking change lands.
