### PR TITLE
Update star-chamber integration for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ flowchart TD
 |----------|----------|-------------|
 | `STAR_CHAMBER_CONFIG` | No | Custom path to star-chamber config (default: `~/.config/star-chamber/providers.json`) |
 | `OTARI_API_BASE` | For `/star-chamber` (Otari mode) | Base URL of your [Otari](https://github.com/mozilla-ai/otari) gateway |
-| `OTARI_API_KEY` | For `/star-chamber` (Otari mode) | Otari gateway API key (or set `OTARI_PLATFORM_TOKEN` for a hosted platform) |
+| `OTARI_AI_TOKEN` | For `/star-chamber` (Otari mode) | Otari hosted platform token (auto-detected by the SDK) |
+| `GATEWAY_API_KEY` | For `/star-chamber` (Otari mode) | Self-hosted Otari gateway API key (auto-detected by the SDK) |
 | `OPENAI_API_KEY` | For `/star-chamber` (direct mode) | OpenAI API key (if not routing through Otari) |
 | `ANTHROPIC_API_KEY` | For `/star-chamber` (direct mode) | Anthropic API key (if not routing through Otari) |
 | `GEMINI_API_KEY` | For `/star-chamber` (direct mode) | Google Gemini API key (if not routing through Otari) |

--- a/plugins/pragma/reference/star-chamber/generate_config.py
+++ b/plugins/pragma/reference/star-chamber/generate_config.py
@@ -10,8 +10,10 @@ Two modes derive from a single direct-keys reference (providers.json):
                 (``openai:gpt-4o``) per Otari's naming convention, then add a
                 top-level ``otari`` block. ``local: true`` providers bypass the
                 gateway and are left untouched. The block templates only
-                ``api_base``; ``api_key`` is omitted so the Otari client resolves
-                ``OTARI_API_KEY`` or falls back to ``OTARI_PLATFORM_TOKEN``.
+                ``api_base``; ``api_key`` is omitted so the SDK's OtariProvider
+                auto-detects credentials from its own env vars
+                (``OTARI_AI_TOKEN`` for platform, ``GATEWAY_API_KEY`` for
+                self-hosted).
 
 NOTE: the ``provider:model`` prefix follows Otari's documented convention; verify
 it against your gateway's docs if a provider rejects the model name.
@@ -56,10 +58,9 @@ def main() -> None:
                 }
             )
         ref["providers"] = rewritten
-        # Template only api_base; omit api_key so the Otari client resolves
-        # OTARI_API_KEY at runtime, or falls back to OTARI_PLATFORM_TOKEN for a
-        # hosted platform. A literal "${OTARI_API_KEY}" would expand to "" when
-        # unset and suppress that fallback.
+        # Template only api_base; omit api_key so the SDK's OtariProvider
+        # auto-detects credentials from its own env vars (OTARI_AI_TOKEN for
+        # platform mode, GATEWAY_API_KEY for self-hosted).
         ref["otari"] = {"api_base": "${OTARI_API_BASE}"}
 
     dest = pathlib.Path.home() / ".config" / "star-chamber" / "providers.json"

--- a/plugins/pragma/skills/star-chamber/PROTOCOL.md
+++ b/plugins/pragma/skills/star-chamber/PROTOCOL.md
@@ -46,7 +46,7 @@ uvx star-chamber <command> [options] [arguments]
 
 `uvx` installs `star-chamber` from PyPI (cached after first run) and executes in isolation — no interference with the host project's environment.
 
-**Version:** This protocol targets star-chamber **0.2.x**, whose config routes gateway traffic through a top-level `otari` object. A pre-0.2 `"platform": "any-llm"` config is rejected by the loader; regenerate it (see Step 0) if you hit that error.
+**Version:** This protocol targets star-chamber **0.3.x**, whose config routes gateway traffic through a top-level `otari` object. A pre-0.2 `"platform": "any-llm"` config is rejected by the loader; regenerate it (see Step 0) if you hit that error.
 
 **Provider SDKs are not all included by default.** Only the OpenAI SDK is a base dependency of `any-llm-sdk`. In **direct** mode, each non-OpenAI provider (Anthropic, Gemini, Cohere, etc.) needs its SDK added via `--with` flags:
 
@@ -92,7 +92,7 @@ Star-Chamber requires provider configuration.
 
 How would you like to manage API keys?
 
-[Otari gateway] - Route all providers through an Otari gateway (OTARI_API_KEY, or OTARI_PLATFORM_TOKEN for a hosted platform)
+[Otari gateway] - Route all providers through an Otari gateway (credentials auto-detected by the SDK)
 [Direct provider keys] - Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY individually
 [Skip] - I'll set it up manually later
 ```
@@ -111,10 +111,10 @@ Created ~/.config/star-chamber/providers.json (Otari gateway mode)
 Setup:
   1. Point at your Otari gateway:
      export OTARI_API_BASE="https://your-gateway.example/v1"
-  2. Authenticate:
-     export OTARI_API_KEY="..."
-     # For a hosted Otari platform with Bearer-token auth, omit OTARI_API_KEY
-     # and set OTARI_PLATFORM_TOKEN instead.
+  2. Authenticate (the SDK auto-detects from its canonical env vars):
+     export OTARI_AI_TOKEN="..."        # hosted platform (Bearer-token auth)
+     # — or —
+     export GATEWAY_API_KEY="..."       # self-hosted gateway
 
 The generated config prefixes each model as provider:model (Otari's naming
 convention). Verify the prefixes against your gateway's docs.
@@ -582,7 +582,7 @@ Auth failures are reported per route: gateway calls report that authentication f
 
 Instead of setting individual provider API keys, you can route every non-local provider through [Otari](https://github.com/mozilla-ai/otari), Mozilla AI's OpenAI-compatible LLM gateway:
 - **Centralized key management** — Provider keys live at the gateway, not on each developer's machine.
-- **Single authentication** — One `OTARI_API_KEY` (or a hosted-platform Bearer token) instead of per-provider keys.
+- **Single authentication** — One credential (`OTARI_AI_TOKEN` or `GATEWAY_API_KEY`) instead of per-provider keys.
 - **Uniform routing** — Otari selects the upstream provider; star-chamber only needs the OpenAI-compatible client.
 
 ### Otari Setup
@@ -601,10 +601,12 @@ Instead of setting individual provider API keys, you can route every non-local p
 3. Point at the gateway and authenticate:
    ```bash
    export OTARI_API_BASE="https://your-gateway.example/v1"
-   export OTARI_API_KEY="..."
+   export OTARI_AI_TOKEN="..."        # hosted platform
+   # — or —
+   export GATEWAY_API_KEY="..."       # self-hosted gateway
    ```
 
-`api_base`/`api_key` may be omitted from the config to resolve from the `OTARI_API_BASE`/`OTARI_API_KEY` environment variables. For a hosted Otari platform that uses Bearer-token auth, omit `OTARI_API_KEY` and set `OTARI_PLATFORM_TOKEN` instead — the Otari client detects it and switches to platform mode automatically.
+`api_base` and `api_key` may be omitted from the config; when omitted, the SDK's `OtariProvider` auto-detects credentials from its own env vars (`OTARI_AI_TOKEN` for platform mode, `GATEWAY_API_KEY` for self-hosted). Both fields also support `${ENV_VAR}` references for explicit values.
 
 Otari expects the `model` field in `provider:model` form; consult Otari's documentation for its exact naming convention. Providers marked `local: true` always bypass the gateway.
 
@@ -634,7 +636,7 @@ Otari expects the `model` field in `provider:model` form; consult Otari's docume
 ```
 - Verify the environment variable is set: `[ -n "$OPENAI_API_KEY" ] && echo "set" || echo "not set"`
 - Check if the key is valid (not expired or revoked).
-- For Otari mode, verify `OTARI_API_KEY` (or `OTARI_PLATFORM_TOKEN`) is set: `{ [ -n "$OTARI_API_KEY" ] || [ -n "$OTARI_PLATFORM_TOKEN" ]; } && echo "set" || echo "not set"`
+- For Otari mode, verify credentials are set: `{ [ -n "$OTARI_AI_TOKEN" ] || [ -n "$GATEWAY_API_KEY" ]; } && echo "set" || echo "not set"`
 
 **Request timed out:**
 ```json


### PR DESCRIPTION
## Summary

- Bump protocol version target from 0.2.x to 0.3.x
- Replace all `OTARI_API_KEY` / `OTARI_PLATFORM_TOKEN` references with the SDK's canonical env vars (`OTARI_AI_TOKEN`, `GATEWAY_API_KEY`)
- Update auth instructions to reflect that credential resolution is now the SDK's responsibility, not star-chamber's fallback chain

Upstream: https://github.com/peteski22/star-chamber/releases/tag/0.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Otari/Star Chamber setup guidance to reflect the latest version and credential naming.
  * Replaced the old authentication reference with the current environment variable names for hosted and self-hosted setups.
  * Refreshed protocol instructions and troubleshooting notes so the documentation matches the current login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->